### PR TITLE
K95 rgb v205 init bug

### DIFF
--- a/src/ckb-daemon/led_keyboard.c
+++ b/src/ckb-daemon/led_keyboard.c
@@ -207,8 +207,13 @@ int loadrgb_kb(usbdevice* kb, lighting* light, int mode){
                 if(!usbrecv(kb, data_pkt[i + clr * 4], in_pkt[i]))
                     return -1;
                 // Make sure the first four bytes match
-                if(memcmp(in_pkt[i], data_pkt[i + clr * 4], 4)){
+				uchar* p = in_pkt[i];
+				if (i > 0) p++;
+                if(memcmp(p, data_pkt[i + clr * 4], 4)){
                     ckb_err("Bad input header\n");
+					ckb_warn("color = %d, i = %d\nInput:  %x %x %x %x %x %x %x %x\nOutput: %x %x %x %x\n", clr, i,
+						in_pkt[i][0], in_pkt[i][1], in_pkt[i][2], in_pkt[i][3], in_pkt[i][4], in_pkt[i][5], in_pkt[i][6], in_pkt[i][7],
+						data_pkt[i + clr * 4][0], 	data_pkt[i + clr * 4 ][1], 	data_pkt[i + clr * 4 ][2], 	data_pkt[i + clr * 4 ][3]);
                     return -1;
                 }
             }


### PR DESCRIPTION
I'm running a K95RGB with a linux mint 18 KDE.
Since the last Firmware upgrade to 2.05 I get the following error-messages in the kernel log:

> Mainfrix	ckb-daemon[1205]	[I] Connecting Corsair K95 RGB Gaming Keyboard at /dev/input/ckb1
> Mainfrix	kernel	[    9.657079] input: ckb1: Corsair K95 RGB Gaming Keyboard as /devices/virtual/input/input25
> Mainfrix	kernel	[    9.657810] input: ckb1: Corsair K95 RGB Gaming Keyboard as /devices/virtual/input/input26
> Mainfrix	ckb-daemon[1205]	[I] Starting input thread for /dev/input/ckb1
> Mainfrix	ckb-daemon[1205]	**[E] loadrgb_kb (led_keyboard.c:211): Bad input header**
> Mainfrix	ckb-daemon[1205]	**[W] _start_dev (device.c:45): Unable to load hardware profile**
> Mainfrix	ckb-daemon[1205]	[I] Setup finished for /dev/input/ckb1

The problem was a different handling of the usb protocol. To fix this, I've written this bugfix.
Now it shows a normal reaction again:

> ckb-daemon[5284]	    ckb: Corsair RGB driver beta-v0.2.7
> ckb-daemon[5284]	[I] Root controller ready at /dev/input/ckb0
> ckb-daemon[5284]	[I] Connecting Corsair K95 RGB Gaming Keyboard at /dev/input/ckb1
> ckb-daemon[5284]	[I] Starting input thread for /dev/input/ckb1
> kernel	[  344.432589] input: ckb1: Corsair K95 RGB Gaming Keyboard as /devices/virtual/input/input34
> kernel	[  344.433091] input: ckb1: Corsair K95 RGB Gaming Keyboard as /devices/virtual/input/input35
> ckb-daemon[5284]	[I] Setup finished for /dev/input/ckb1

Because I cannot test it with different keyboards, please insert the code in a very early testing stage.