### PR TITLE
Master issue 48 segfault with k70 rgb in bios mode

### DIFF
--- a/src/ckb-daemon/usb.c
+++ b/src/ckb-daemon/usb.c
@@ -205,7 +205,7 @@ int _usbsend(usbdevice* kb, const uchar* messages, int count, const char* file, 
 }
 
 int _usbrecv(usbdevice* kb, const uchar* out_msg, uchar* in_msg, const char* file, int line){
-    // Try a maximum of 3 times
+    // Try a maximum of 5 times
     for(int try = 0; try < 5; try++){
         // Send the output message
         DELAY_SHORT(kb);

--- a/src/ckb-daemon/usb.h
+++ b/src/ckb-daemon/usb.h
@@ -84,7 +84,7 @@ const char* product_str(short product);
 #define IS_MOUSE_DEV(kb)                IS_MOUSE((kb)->vendor, (kb)->product)
 
 // USB delays for when the keyboards get picky about timing
-#define DELAY_SHORT(kb)     usleep((int)(kb)->usbdelay * 1000)  // base (default: 5ms)
+#define DELAY_SHORT(kb)     usleep((int)(kb)->usbdelay * 2000)  // base (default: 10ms for testing mode-switch of RGB keyboards)
 #define DELAY_MEDIUM(kb)    usleep((int)(kb)->usbdelay * 10000) // x10 (default: 50ms)
 #define DELAY_LONG(kb)      usleep(100000)                      // long, fixed 100ms
 #define USB_DELAY_DEFAULT   5

--- a/src/ckb-daemon/usb_linux.c
+++ b/src/ckb-daemon/usb_linux.c
@@ -94,10 +94,14 @@ void* os_inputmain(void* context){
     // Monitor input transfers on all endpoints for non-RGB devices
     // For RGB, monitor all but the last, as it's used for input/output
     int urbcount = IS_RGB(vendor, product) ? (kb->epcount - 1) : kb->epcount;
+    if (urbcount == 0) {
+        ckb_warn("urbcount = 0, so there is nothing to claim in os_inputmain()\n");
+        return 0;
+    }
     struct usbdevfs_urb urbs[urbcount];
     memset(urbs, 0, sizeof(urbs));
     urbs[0].buffer_length = 8;
-    if(IS_RGB(vendor, product)){
+    if(urbcount > 1 && IS_RGB(vendor, product)) {
         if(IS_MOUSE(vendor, product))
             urbs[1].buffer_length = 10;
         else
@@ -219,11 +223,15 @@ void os_closeusb(usbdevice* kb){
 
 int usbclaim(usbdevice* kb){
     int count = kb->epcount;
+    ckb_info("claiming %d endpoints\n", count);
+
     for(int i = 0; i < count; i++){
         struct usbdevfs_ioctl ctl = { i, USBDEVFS_DISCONNECT, 0 };
         ioctl(kb->handle - 1, USBDEVFS_IOCTL, &ctl);
-        if(ioctl(kb->handle - 1, USBDEVFS_CLAIMINTERFACE, &i))
+        if(ioctl(kb->handle - 1, USBDEVFS_CLAIMINTERFACE, &i)) {
+            ckb_err("Failed to claim interface %d: %s\n", i, strerror(errno));
             return -1;
+        }
     }
     return 0;
 }
@@ -284,13 +292,18 @@ int os_setupusb(usbdevice* kb){
 
     // Claim the USB interfaces
     const char* ep_str = udev_device_get_sysattr_value(dev, "bNumInterfaces");
+    ckb_info("claiming interfaces. name=%s, serial=%s, firmware=%s; Got >>%s<< as ep_str\n", name, serial, firmware, ep_str);
     kb->epcount = 0;
     if(ep_str)
         sscanf(ep_str, "%d", &kb->epcount);
-    if(kb->epcount == 0){
+    if(kb->epcount < 2){
+        // IF we have an RGB KB with 0 or 1 endpoints, it will be in BIOS mode.
+        ckb_warn("Possible unable to read endpoint count from udev, assuming %d and reading >>%s<<...\n", kb->epcount, ep_str);
+        return -1;
+        // ToDo lae. are there special versions we have to detect?
         // This shouldn't happen, but if it does, assume EP count based on what the device is supposed to have
         kb->epcount = (HAS_FEATURES(kb, FEAT_RGB) ? 4 : 3);
-        ckb_warn("Unable to read endpoint count from udev, assuming %d...\n", kb->epcount);
+        ckb_warn("Unable to read endpoint count from udev, assuming %d and reading >>%s<<...\n", kb->epcount, ep_str);
     }
     if(usbclaim(kb)){
         ckb_err("Failed to claim interfaces: %s\n", strerror(errno));
@@ -306,6 +319,8 @@ int usbadd(struct udev_device* dev, short vendor, short product){
         ckb_err("Failed to get device path\n");
         return -1;
     }
+    //lae.
+    ckb_info(">>>vendor = 0x%x, product = 0x%x, path = %s, syspath = %s\n", vendor, product, path, syspath);
     // Find a free USB slot
     for(int index = 1; index < DEV_MAX; index++){
         usbdevice* kb = keyboard + index;

--- a/src/ckb-daemon/usb_linux.c
+++ b/src/ckb-daemon/usb_linux.c
@@ -6,6 +6,8 @@
 
 #ifdef OS_LINUX
 
+#define DEBUG
+
 static char kbsyspath[DEV_MAX][FILENAME_MAX];
 
 int os_usbsend(usbdevice* kb, const uchar* out_msg, int is_recv, const char* file, int line){
@@ -95,7 +97,7 @@ void* os_inputmain(void* context){
     // For RGB, monitor all but the last, as it's used for input/output
     int urbcount = IS_RGB(vendor, product) ? (kb->epcount - 1) : kb->epcount;
     if (urbcount == 0) {
-        ckb_warn("urbcount = 0, so there is nothing to claim in os_inputmain()\n");
+        ckb_err("urbcount = 0, so there is nothing to claim in os_inputmain()\n");
         return 0;
     }
     struct usbdevfs_urb urbs[urbcount];
@@ -223,7 +225,9 @@ void os_closeusb(usbdevice* kb){
 
 int usbclaim(usbdevice* kb){
     int count = kb->epcount;
+#ifdef DEBUG
     ckb_info("claiming %d endpoints\n", count);
+#endif // DEBUG
 
     for(int i = 0; i < count; i++){
         struct usbdevfs_ioctl ctl = { i, USBDEVFS_DISCONNECT, 0 };
@@ -288,22 +292,23 @@ int os_setupusb(usbdevice* kb){
     else
         kb->fwversion = 0;
     int index = INDEX_OF(kb, keyboard);
-    ckb_info("Connecting %s at %s%d\n", kb->name, devpath, index);
-
     // Claim the USB interfaces
     const char* ep_str = udev_device_get_sysattr_value(dev, "bNumInterfaces");
+#ifdef DEBUG
+    ckb_info("Connecting %s at %s%d\n", kb->name, devpath, index);
     ckb_info("claiming interfaces. name=%s, serial=%s, firmware=%s; Got >>%s<< as ep_str\n", name, serial, firmware, ep_str);
+#endif //DEBUG
     kb->epcount = 0;
     if(ep_str)
         sscanf(ep_str, "%d", &kb->epcount);
     if(kb->epcount < 2){
         // IF we have an RGB KB with 0 or 1 endpoints, it will be in BIOS mode.
-        ckb_warn("Possible unable to read endpoint count from udev, assuming %d and reading >>%s<<...\n", kb->epcount, ep_str);
+        ckb_err("Possibly unable to read endpoint count from udev, assuming %d and reading >>%s<<...\n", kb->epcount, ep_str);
         return -1;
-        // ToDo lae. are there special versions we have to detect?
-        // This shouldn't happen, but if it does, assume EP count based on what the device is supposed to have
-        kb->epcount = (HAS_FEATURES(kb, FEAT_RGB) ? 4 : 3);
-        ckb_warn("Unable to read endpoint count from udev, assuming %d and reading >>%s<<...\n", kb->epcount, ep_str);
+        // ToDo are there special versions we have to detect? If there are, that was the old code to handle it:
+        // This shouldn't happen, but if it does, assume EP count based onckb_warn what the device is supposed to have
+        // kb->epcount = (HAS_FEATURES(kb, FEAT_RGB) ? 4 : 3);
+        // ckb_warn("Unable to read endpoint count from udev, assuming %d and reading >>%s<<...\n", kb->epcount, ep_str);
     }
     if(usbclaim(kb)){
         ckb_err("Failed to claim interfaces: %s\n", strerror(errno));
@@ -319,8 +324,9 @@ int usbadd(struct udev_device* dev, short vendor, short product){
         ckb_err("Failed to get device path\n");
         return -1;
     }
-    //lae.
+#ifdef DEBUG
     ckb_info(">>>vendor = 0x%x, product = 0x%x, path = %s, syspath = %s\n", vendor, product, path, syspath);
+#endif // DEDBUG
     // Find a free USB slot
     for(int index = 1; index < DEV_MAX; index++){
         usbdevice* kb = keyboard + index;


### PR DESCRIPTION
This pullrequest avoids the most important crashes of the daemon when the polling switches on the RGB keyboards are changed.
Unfortunately, the cause of the error is the co-working of the keyboard firmware, the Linux USB driver and the ckb-daemon.

I have tried different test combinations with my K95RGB and M65RGB mouse. The result can be found here: [Test matrix.pdf](https://github.com/mattanger/ckb-next/files/753065/Test.matrix.pdf).
In short, even without the ckb-daemon you can bring the USB driver or even the keyboard itself to crash by moving the state-switches. 
This is only supplemented by the daemon, so that the user is completely irritated and the cause of the error can no longer be identified.

What I found was a hint in the usb driver about the delays before sending a message: 5ms was the standard. Because I had a lot of trouble with the 8ms settinngs for my K95RGB, I tried to double this delay. It works a lot better, even not perfect.
My suggestion is that we use that increased setting and observe whether we get a timing problem elsewhere.

If you are interested: I have several logfiles from the usb communication to show with wireshark or vusb-analyzer

The following info may be helpful for our users in the README.md file.
But first please check with your HW (K70xxx and others), if that change work for you.

The most reliable way to switch is by following that order:
- Unplug the keyboard first,
- switch the mode,
- wait a few seconds (about 10; this time is for your usb driver to detect the disconnect. This is done very fast normally, but these state transfers are all but normally...)
- reconnect the keyboard
- have a look at you system logs (or stdout, if you have called the ckb-daemon manually). 
After maximum 15 seconds it should inform you about having started the communication with the KB.

If after 15 seconds the keyboard remains dark or simply not react, the daemon should be killed, the keyboard unplugged and after 15 seconds replugged.
The times may vary depending on your system: It is needed for the usb driver to detect the reconnection of the usb device. 

Please try killing the daemon gently first with "sudo pkill ckb-daemon", because with this it does some cleanup. 
Only if the process wont stop (there is a situation with a loop between kernel and daemon), kill it tough and then clean up manually. Example for Linux:
`
sudo pkill -9 ckb-daemon; sudo rm -rf /dev/input/ckb*  # be careful with this statement!!!
`
If you do not clean up and have a lot of testing, you will have too many devices in the directory (max 10 allowed).

references #48 