### PR TITLE
Fixes error #38 SIGSEGV when deleting copied profile

### DIFF
--- a/src/ckb/kbbind.cpp
+++ b/src/ckb/kbbind.cpp
@@ -14,10 +14,37 @@ KbBind::KbBind(KbMode* modeParent, Kb* parentBoard, const KeyMap& keyMap) :
     _winLock(false), _needsUpdate(true), _needsSave(true) {
 }
 
+///
+/// \brief KbBind::KbBind   // copy all existing Key bindings
+/// \param modeParent
+/// \param parentBoard
+/// \param keyMap
+/// \param other
+///
 KbBind::KbBind(KbMode* modeParent, Kb* parentBoard, const KeyMap& keyMap, const KbBind& other) :
     QObject(modeParent), _devParent(parentBoard), lastGlobalRemapTime(globalRemapTime), _bind(other._bind),
     _winLock(false), _needsUpdate(true), _needsSave(true) {
     map(keyMap);
+
+    /// Create a new Hash table and copy all entries
+    QHash<QString, KeyAction*> newBind;
+    foreach(QString key, _bind.keys()) {
+        KeyAction* act = _bind.value(key);
+        if(act) {
+            newBind[key] = new KeyAction(act->value(), this);
+        }
+    }
+
+    /// clear the destination list (there are the original KeyActions as references, so do not delete them)
+    _bind.clear();
+    foreach(QString key, newBind.keys()) {
+        KeyAction* act = newBind.value(key);
+        if(act) {
+            /// and move the KeyActions we just created
+            _bind[key] = new KeyAction(act->value(), this);
+        }
+    }
+    newBind.clear();      // here we *must not* delete the KeyActions, because they are referenced by _bind now
 }
 
 KbPerf* KbBind::perf(){

--- a/src/ckb/kbbind.h
+++ b/src/ckb/kbbind.h
@@ -23,7 +23,13 @@ class KbBind : public QObject
 public:
     // New binding setup
     explicit KbBind(KbMode* modeParent, Kb* devParent, const KeyMap& keyMap);
-    // Copy a binding setup
+    ///
+    /// \brief KbBind
+    /// \param modeParent
+    /// \param devParent
+    /// \param keyMap
+    /// \param other        This is the KbBind object to copy from
+    /// Use this constructor to copy an existing Binding
     KbBind(KbMode* modeParent, Kb* devParent, const KeyMap& keyMap, const KbBind& other);
 
     // Load and save from stored settings

--- a/src/ckb/kbmode.cpp
+++ b/src/ckb/kbmode.cpp
@@ -12,6 +12,12 @@ KbMode::KbMode(Kb* parent, const KeyMap& keyMap, const QString &guid, const QStr
         _id.guid = QUuid::createUuid();
 }
 
+///
+/// \brief KbMode::KbMode
+/// \param parent   Kb as parent (append to the Keyboard list
+/// \param keyMap   Map to copy from
+/// \param other    Mode to copy from
+/// Constructor to copy an existing Keyboard-Mode KbMode &other
 KbMode::KbMode(Kb* parent, const KeyMap& keyMap, const KbMode& other) :
     QObject(parent),
     _name(other._name), _id(other._id),
@@ -75,4 +81,10 @@ bool KbMode::needsSave() const {
 
 void KbMode::doUpdate(){
     emit updated();
+}
+
+///
+/// \brief KbMode::~KbMode
+/// Destructor may be used for Debugging (issue #38 with SIGSEGV). Insert qDebug-statement
+KbMode::~KbMode() {
 }

--- a/src/ckb/kbmode.h
+++ b/src/ckb/kbmode.h
@@ -44,6 +44,8 @@ public:
     // Mode by copy
     KbMode(Kb* parent, const KeyMap& keyMap, const KbMode& other);
 
+    ~KbMode();
+
     // Mode properties
     inline const QString&   name() const                    { return _name; }
     inline void             name(const QString& newName)    { _needsSave = true; _name = newName.trimmed(); if(_name == "") _name = "Unnamed"; }

--- a/src/ckb/kbwidget.cpp
+++ b/src/ckb/kbwidget.cpp
@@ -226,6 +226,13 @@ void KbWidget::on_modesList_itemClicked(QListWidgetItem* item){
     }
 }
 
+///
+/// \brief KbWidget::on_modesList_customContextMenuRequested
+/// \param pos
+/// Opens on right click in the profiles list a context sensitive menue
+/// at position pos.
+///
+/// When clicking on a command it is located and executed.
 void KbWidget::on_modesList_customContextMenuRequested(const QPoint &pos){
     QListWidgetItem* item = ui->modesList->itemAt(pos);
     if(!item || !currentMode || item->data(GUID).toUuid() != currentMode->id().guid)

--- a/src/ckb/keyaction.h
+++ b/src/ckb/keyaction.h
@@ -160,7 +160,8 @@ public:
 
     ~KeyAction();
 private:
-    // Don't copy key actions (the old one needs to be deleted first)
+    /// ccMSC: Don't copy key actions (the old one needs to be deleted first)
+    /// frickler24: statement left as described, but copying is done in KbBind copy constructor
     inline void operator=(const KeyAction& rhs) {}
     inline KeyAction(const KeyAction& rhs) : QObject() {}
 


### PR DESCRIPTION
This error was caused by not completely copying a mode.
The KeyActions always referenced the original data and were not copied.
The commit fixes this and adds a few comments in the modules
where I passed while debugging.

This PR replaces #72, which was based on master.

Fixes #38.