### PR TITLE
Testing+issue97 k70 lux firmware update fails

### DIFF
--- a/src/ckb-daemon/command.c
+++ b/src/ckb-daemon/command.c
@@ -205,7 +205,7 @@ int readcmd(usbdevice* kb, const char* line){
             continue;
         case RESTART: {
             char mybuffer[] = "no reason specified";
-            if (sscanf(line, " %[^\n]", word) == -1) { ///> Because length of word is length of line + 1, there should be no problem with buffer overflow.
+            if (sscanf(line, " %[^\n]", word) == -1) { ///< Because length of word is length of line + 1, there should be no problem with buffer overflow.
                 word = mybuffer;
             }
             vt->do_cmd[command](kb, mode, notifynumber, 0, word);

--- a/src/ckb-daemon/devnode.c
+++ b/src/ckb-daemon/devnode.c
@@ -285,7 +285,7 @@ int mkfwnode(usbdevice* kb){
     snprintf(fwpath, sizeof(fwpath), "%s%d/fwversion", devpath, index);
     FILE* fwfile = fopen(fwpath, "w");
     if(fwfile){
-        fprintf(fwfile, "%04x", kb->fwversion);
+        fprintf(fwfile, "%04x:0x%04x:0x%04x", kb->fwversion, kb->vendor, kb->product);
         fputc('\n', fwfile);
         fclose(fwfile);
         chmod(fwpath, S_GID_READ);

--- a/src/ckb-daemon/structures.h
+++ b/src/ckb-daemon/structures.h
@@ -246,8 +246,8 @@ typedef struct {
     uchar hw_ileds, hw_ileds_old, ileds;
     // Color dithering in use
     char dither;
-    // Flag to check, if large macros should be sent delayed
-    char delay;
+    // Flag to check if large macros should be sent delayed
+    uint delay;
 } usbdevice;
 
 #endif  // STRUCTURES_H

--- a/src/ckb/ckb.pro
+++ b/src/ckb/ckb.pro
@@ -159,7 +159,8 @@ HEADERS  += mainwindow.h \
     extrasettingswidget.h \
     kbmanager.h \
     colormap.h \
-    macroreader.h
+    macroreader.h \
+    firmware_special.h
 
 FORMS    += mainwindow.ui \
     kbwidget.ui \

--- a/src/ckb/firmware_special.h
+++ b/src/ckb/firmware_special.h
@@ -1,0 +1,33 @@
+#ifndef FIRMWARE_SPECIAL_H
+#define FIRMWARE_SPECIAL_H
+#include "keymap.h"
+
+/// \file Define vendor:product combinations, whicxh need special treatment in firmware detection.
+/// This may be neccessary, if a new hardware uses the same features as an older hardware,
+/// but  needs a completely different firmware-file or -version.
+
+/// To reduce effort, please insert only these combinations, whcih need really special treatment.
+/// All other models will further be identified by their featrur-lists.
+///
+/// And - please - add a comment, why this antry is needed.
+
+/// Don't change this. If Corsair is not corsair any more, we have a different problem...
+#define V_CORSAIR       0x1b1c
+#define P_K70_LUX_NRGB	     0x1b36
+
+struct firmwareSpecial {
+    const short product;
+    const KeyMap::Model model;
+} specials[] = {
+
+    /// ckb-next Issue #97:
+    /// client tries to install a firmware for ProductID 0x1b13 (K70) into the device with productID 0x1b36 (K70_LUX_NRGB).
+    /// Reason is, that 0x1b36 is non-RGB, but hast Lightning.
+    /// cat features: corsair k70 rgb pollrate bind notify fwversion fwupdate
+    /// cat model: Corsair Gaming K70 LUX Keyboard
+    ///
+    /// Because it detects "rgb", the standard choice is K70. We have to it to K70_LUX (0x1b33).
+    { P_K70_LUX_NRGB, KeyMap::K70},
+};
+
+#endif // FIRMWARE_SPECIAL_H

--- a/src/ckb/firmware_special.h
+++ b/src/ckb/firmware_special.h
@@ -1,18 +1,20 @@
 #ifndef FIRMWARE_SPECIAL_H
 #define FIRMWARE_SPECIAL_H
-#include "keymap.h"
+#include "keymap.h"     ///< Just to be sure. Currently the file is included before firmware-special.h (keymap.cpp)
 
-/// \file Define vendor:product combinations, whicxh need special treatment in firmware detection.
-/// This may be neccessary, if a new hardware uses the same features as an older hardware,
+/// \file Define vendor:product combinations, which need special treatment in firmware detection.
+/// This may be necessary, if a new hardware uses the same features as an older hardware,
 /// but  needs a completely different firmware-file or -version.
 
-/// To reduce effort, please insert only these combinations, whcih need really special treatment.
-/// All other models will further be identified by their featrur-lists.
+/// To reduce effort, please insert these combinations only, which need really special treatment.
+/// All other models will further be identified by their feature-lists.
 ///
-/// And - please - add a comment, why this antry is needed.
+/// And - please - add a comment, why this entry is needed.
 
 /// Don't change this. If Corsair is not corsair any more, we have a different problem...
 #define V_CORSAIR       0x1b1c
+
+/// Enter the Product ID of your device you want to handle with special treatment
 #define P_K70_LUX_NRGB	     0x1b36
 
 struct firmwareSpecial {
@@ -26,8 +28,8 @@ struct firmwareSpecial {
     /// cat features: corsair k70 rgb pollrate bind notify fwversion fwupdate
     /// cat model: Corsair Gaming K70 LUX Keyboard
     ///
-    /// Because it detects "rgb", the standard choice is K70. We have to it to K70_LUX (0x1b33).
-    { P_K70_LUX_NRGB, KeyMap::K70},
+    /// Because it detects "rgb", the standard choice is K70. We have to map it to K70_LUX (0x1b33).
+    { P_K70_LUX_NRGB, KeyMap::K70 },
 };
 
 #endif // FIRMWARE_SPECIAL_H

--- a/src/ckb/fwupgradedialog.cpp
+++ b/src/ckb/fwupgradedialog.cpp
@@ -15,16 +15,16 @@ struct KbId {
 
 static KbId ids[] = {
     // Keyboards
-    { 0x1b1c, 0x1b17, "corsair k65 rgb"},
-    { 0x1b1c, 0x1b13, "corsair k70 rgb"},
-    { 0x1b1c, 0x1b11, "corsair k95 rgb"},
-    { 0x1b1c, 0x1b15, "corsair strafe monochrome"},
-    { 0x1b1c, 0x1b20, "corsair strafe rgb"},
+    { 0x1b1c, 0x1b17, "corsair k65 rgb" },
+    { 0x1b1c, 0x1b13, "corsair k70 rgb" },
+    { 0x1b1c, 0x1b11, "corsair k95 rgb" },
+    { 0x1b1c, 0x1b15, "corsair strafe monochrome" },
+    { 0x1b1c, 0x1b20, "corsair strafe rgb" },
     // Mice
-    { 0x1b1c, 0x1b12, "corsair m65 rgb"},
-    { 0x1b1c, 0x1b1e, "corsair scimitar rgb"},
+    { 0x1b1c, 0x1b12, "corsair m65 rgb" },
+    { 0x1b1c, 0x1b1e, "corsair scimitar rgb" },
     //SABRE CH-9000111-EU
-    { 0x1b1c, 0x1b32, "corsair sabre optical rgb"}
+    { 0x1b1c, 0x1b32, "corsair sabre optical rgb" }
 };
 
 static const int DIALOG_WIDTH = 420;

--- a/src/ckb/fwupgradedialog.cpp
+++ b/src/ckb/fwupgradedialog.cpp
@@ -4,7 +4,9 @@
 #include "kbfirmware.h"
 #include "ui_fwupgradedialog.h"
 
-// IDs for verifying firmware suitability
+/// \brief IDs for verifying firmware suitability
+/// Some newer hardware models have the same features as older ones, but need a different firmware version number
+/// but not a different firmware file.
 struct KbId {
     short vendor;
     short product;
@@ -13,16 +15,16 @@ struct KbId {
 
 static KbId ids[] = {
     // Keyboards
-    { 0x1b1c, 0x1b17, "corsair k65 rgb" },
-    { 0x1b1c, 0x1b13, "corsair k70 rgb" },
-    { 0x1b1c, 0x1b11, "corsair k95 rgb" },
-    { 0x1b1c, 0x1b15, "corsair strafe monochrome" },
-    { 0x1b1c, 0x1b20, "corsair strafe rgb" },
+    { 0x1b1c, 0x1b17, "corsair k65 rgb"},
+    { 0x1b1c, 0x1b13, "corsair k70 rgb"},
+    { 0x1b1c, 0x1b11, "corsair k95 rgb"},
+    { 0x1b1c, 0x1b15, "corsair strafe monochrome"},
+    { 0x1b1c, 0x1b20, "corsair strafe rgb"},
     // Mice
-    { 0x1b1c, 0x1b12, "corsair m65 rgb" },
-    { 0x1b1c, 0x1b1e, "corsair scimitar rgb" },
+    { 0x1b1c, 0x1b12, "corsair m65 rgb"},
+    { 0x1b1c, 0x1b1e, "corsair scimitar rgb"},
     //SABRE CH-9000111-EU
-    { 0x1b1c, 0x1b32, "corsair sabre optical rgb" }
+    { 0x1b1c, 0x1b32, "corsair sabre optical rgb"}
 };
 
 static const int DIALOG_WIDTH = 420;

--- a/src/ckb/kb.cpp
+++ b/src/ckb/kb.cpp
@@ -5,6 +5,7 @@
 #include <QDateTime>
 #include "kb.h"
 #include "kbmanager.h"
+#include <qdebug.h>
 
 // All active devices
 static QSet<Kb*> activeDevices;
@@ -60,8 +61,10 @@ Kb::Kb(QObject *parent, const QString& path) :
     if(usbSerial == "")
         usbSerial = "Unknown-" + usbModel;
     if(features.contains("fwversion") && fwpath.open(QIODevice::ReadOnly)){
-        firmware = fwpath.read(100);
-        firmware = QString::number(firmware.trimmed().toInt() / 100., 'f', 2);
+        QString firmwareString = fwpath.read(100);
+        QStringList firmwareList = firmwareString.split(":");
+        qDebug() << "Firmware Version read from ckb-daemon in fwversion file is" << firmwareList.at(0) << ", VID=" << firmwareList.at(1) << ", PID=" << firmwareList.at(2);
+        firmware = QString::number(firmwareList.at(0).trimmed().toInt() / 100., 'f', 2);
         fwpath.close();
     }
     if(features.contains("pollrate") && ppath.open(QIODevice::ReadOnly)){

--- a/src/ckb/kb.cpp
+++ b/src/ckb/kb.cpp
@@ -35,14 +35,14 @@ Kb::Kb(QObject *parent, const QString& path) :
         fwString = fwString.trimmed();
         fwpath.close();
         QStringList list = fwString.split(":");
-        if(list.length() == 3) {    ///> Firmware Info is now current fw-number:vendor:model
+        if(list.length() == 3) {    ///< Firmware Info is now current fw-number:vendor:model
             /// Look for special entries (newest models)
             bool okVendor, okProduct;
             const uint vendor = list[1].toUInt(&okVendor, 16);
             const uint product = list[2].toUInt(&okProduct, 16);
-            if (okVendor && okProduct) _model = KeyMap::getModel(vendor, product);    ///> perhaps we have found something, perhaps not.
-            qDebug() << "first look for special firmware returned" << _model;
-        }
+            if (okVendor && okProduct) _model = KeyMap::getModel(vendor, product);    ///< perhaps we have found something, perhaps not.
+            qInfo() << "first look for special firmware returned" << _model;
+        } else qWarning() << "Expected 3 entries in file" << fwpath.fileName() << "but reading" << list.length();
     }
     if(ftpath.open(QIODevice::ReadOnly)){
         features = ftpath.read(1000);
@@ -52,12 +52,12 @@ Kb::Kb(QObject *parent, const QString& path) :
         QStringList list = features.split(" ");
         if(list.length() < 2)
             return;
-        if (_model == KeyMap::NO_MODEL) {   ///> If nothing found in the special firmware search, try here.
+        if (_model == KeyMap::NO_MODEL) {   ///< If nothing found in the special firmware search, try here.
             _model = KeyMap::getModel(list[1]);
         }
         /// Last chance gone to get a valid firmware information.
         if (_model == KeyMap::NO_MODEL) {
-            qWarning() << "Neither firmware-special-search nor feature file analysis resulted in valid firmware information.";
+            qCritical() << "Neither firmware-special-search nor feature file analysis resulted in valid firmware information.";
             return;
         }
     } else
@@ -81,10 +81,21 @@ Kb::Kb(QObject *parent, const QString& path) :
         usbSerial = "Unknown-" + usbModel;
     if(features.contains("fwversion") && fwpath.open(QIODevice::ReadOnly)){
         QString firmwareString = fwpath.read(100);
-        QStringList firmwareList = firmwareString.split(":");
-        qDebug() << "Firmware Version read from ckb-daemon in fwversion file is" << firmwareList.at(0) << ", VID=" << firmwareList.at(1) << ", PID=" << firmwareList.at(2);
-        firmware = QString::number(firmwareList.at(0).trimmed().toInt() / 100., 'f', 2);
         fwpath.close();
+
+        /// Handle inputs
+        QStringList firmwareList = firmwareString.remove("\n").split(":");
+        switch (firmwareList.length()) {
+        case 3: ///< This is the normal case if we have a new daemon and a running device
+            qInfo() << "Reading 3 entries from fwversion file, VID=" << firmwareList.at(1) << ", PID=" << firmwareList.at(2);
+        case 1: ///< That means we have an older daemon which does not write three infos into the file
+            firmware = QString::number(firmwareList.at(0).trimmed().toInt() / 100., 'f', 2);
+            qInfo() << "Firmware version read from ckb-daemon in fwversion file is" << firmwareList.at(0);
+            break;
+        default:
+            qCritical() << "Firware version file is invalid. Number of entries is" << firmwareList.length();
+            break;
+        }
     }
     if(features.contains("pollrate") && ppath.open(QIODevice::ReadOnly)){
         pollrate = ppath.read(100);

--- a/src/ckb/keyaction.cpp
+++ b/src/ckb/keyaction.cpp
@@ -438,7 +438,7 @@ void KeyAction::macroDisplay() {
     qDebug() << "isMacro returns" << (isMacro() ? "true" : "false");
     qDebug() << "isValidMacro returns" << (isValidMacro() ? "true" : "false");
     QStringList ret =_value.split(":");
-    qDebug() << "Macro definition conains" << ret.count() << "elements";
+    qDebug() << "Macro definition contains" << ret.count() << "elements";
     qDebug() << "Macro definition is" << _value;
 }
 

--- a/src/ckb/keymap.cpp
+++ b/src/ckb/keymap.cpp
@@ -1,6 +1,8 @@
 #include <clocale>
 #include <QMap>
+#include <QDebug>
 #include "keymap.h"
+#include "firmware_special.h"
 
 // Normal key size
 #define NS 12, 12
@@ -492,6 +494,29 @@ QStringList KeyMap::layoutNames(){
             << "Swedish";
 }
 
+///
+/// \brief KeyMap::getModel get the KeyMap::Model from the vendor / product special table.
+/// Use this function first, if you want to determine the firmware version to load or check.
+/// \param vendor Corsair's vendor ID V_CORSAIR - just to be sure...
+/// \param myProduct the productID of your USB device
+/// \return the corresponding KeyMap::Model if the v/p-combination could be found, NO_MODEL else.
+///
+KeyMap::Model KeyMap::getModel(const short vendor, const short myProduct){
+    if (vendor != V_CORSAIR) {
+        qCritical() << "Wrong vendor number" << vendor << "with product number" << myProduct;
+        return NO_MODEL;
+    }
+    for (uint i = 0; i < sizeof(specials)/sizeof(struct firmwareSpecial)  ; i++) {
+        if (specials[i].product == myProduct) return specials[i].model;
+    }
+    return NO_MODEL;
+}
+
+///
+/// \brief KeyMap::getModel KeyMap model name.
+/// \param name QString with the name from "features" file
+/// \return the corresponding KeyMap::Model or NO_MODEL (-1), if name does not exist.
+///
 KeyMap::Model KeyMap::getModel(const QString& name){
     QString lower = name.toLower();
     if(lower == "k65")
@@ -511,6 +536,11 @@ KeyMap::Model KeyMap::getModel(const QString& name){
     return NO_MODEL;
 }
 
+///
+/// \brief KeyMap::getModel get the KeyMap name from the KeyMap::Model.
+/// \param model KeyMap::Model
+/// \return QString with model name or "" if model exceeds boundaries
+///
 QString KeyMap::getModel(KeyMap::Model model){
     switch(model){
     case K65:

--- a/src/ckb/keymap.h
+++ b/src/ckb/keymap.h
@@ -104,7 +104,8 @@ public:
     static Layout   getLayout(const QString& name);
     static QString  getLayout(Layout layout);
     inline QString  strLayout() const { return getLayout(keyLayout); }
-    // Gets a model by name or name by model
+    // Gets a model by name or vendor:product or name by model
+    static Model    getModel(const short vendor, const short product);
     static Model    getModel(const QString& name);
     static QString  getModel(Model model);
     inline QString  strModel() const { return getModel(keyModel); }

--- a/src/ckb/rebindwidget.ui
+++ b/src/ckb/rebindwidget.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>5</number>
      </property>
      <widget class="QWidget" name="keyTab">
       <property name="sizePolicy">
@@ -1433,9 +1433,135 @@
         <string>Comment label for help</string>
        </property>
       </widget>
+      <widget class="QWidget" name="layoutWidget_delay">
+       <property name="geometry">
+        <rect>
+         <x>40</x>
+         <y>170</y>
+         <width>238</width>
+         <height>28</height>
+        </rect>
+       </property>
+       <layout class="QHBoxLayout" name="delayButtons">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="sizeConstraint">
+         <enum>QLayout::SetMinimumSize</enum>
+        </property>
+        <item>
+         <widget class="QRadioButton" name="rb_delay_no">
+          <property name="whatsThis">
+           <string>configure delays between keystrokes: Disable delay</string>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">font: 10pt ; color:  green;</string>
+          </property>
+          <property name="text">
+           <string>No delay</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="rb_delay_default">
+          <property name="whatsThis">
+           <string>configure delays between keystrokes: Set delay to default values: 20us up to 15 chars, 200us above</string>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">font: 10pt ; color:  green;</string>
+          </property>
+          <property name="text">
+           <string>default</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+          <property name="autoExclusive">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QRadioButton" name="rb_delay_asTyped">
+          <property name="whatsThis">
+           <string>configure delays between keystrokes: Remember delays as they had been typed while the macro definition process</string>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">font: 10pt ; color:  green;</string>
+          </property>
+          <property name="text">
+           <string>as typed</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QLabel" name="txtBuffer">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="geometry">
+        <rect>
+         <x>300</x>
+         <y>100</y>
+         <width>0</width>
+         <height>0</height>
+        </rect>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="contextMenuPolicy">
+        <enum>Qt::NoContextMenu</enum>
+       </property>
+       <property name="toolTip">
+        <string notr="true"/>
+       </property>
+       <property name="toolTipDuration">
+        <number>0</number>
+       </property>
+       <property name="statusTip">
+        <string notr="true"/>
+       </property>
+       <property name="whatsThis">
+        <string notr="true"/>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Plain</enum>
+       </property>
+       <property name="lineWidth">
+        <number>0</number>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::PlainText</enum>
+       </property>
+       <property name="indent">
+        <number>0</number>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::NoTextInteraction</set>
+       </property>
+      </widget>
       <zorder>pteMacroComment</zorder>
-      <zorder>layoutWidget1</zorder>
       <zorder>layoutWidget</zorder>
+>>>>>>> 450e80a... handle specials in firmware upgrade: Detection of correct version
+      <zorder>layoutWidget1</zorder>
+      <zorder>layoutWidget_delay</zorder>
       <zorder>pteMacroText</zorder>
       <zorder>layoutWidget_2</zorder>
       <zorder>lbl_macro</zorder>

--- a/src/ckb/rebindwidget.ui
+++ b/src/ckb/rebindwidget.ui
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>5</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="keyTab">
       <property name="sizePolicy">
@@ -1433,135 +1433,9 @@
         <string>Comment label for help</string>
        </property>
       </widget>
-      <widget class="QWidget" name="layoutWidget_delay">
-       <property name="geometry">
-        <rect>
-         <x>40</x>
-         <y>170</y>
-         <width>238</width>
-         <height>28</height>
-        </rect>
-       </property>
-       <layout class="QHBoxLayout" name="delayButtons">
-        <property name="spacing">
-         <number>0</number>
-        </property>
-        <property name="sizeConstraint">
-         <enum>QLayout::SetMinimumSize</enum>
-        </property>
-        <item>
-         <widget class="QRadioButton" name="rb_delay_no">
-          <property name="whatsThis">
-           <string>configure delays between keystrokes: Disable delay</string>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">font: 10pt ; color:  green;</string>
-          </property>
-          <property name="text">
-           <string>No delay</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="rb_delay_default">
-          <property name="whatsThis">
-           <string>configure delays between keystrokes: Set delay to default values: 20us up to 15 chars, 200us above</string>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">font: 10pt ; color:  green;</string>
-          </property>
-          <property name="text">
-           <string>default</string>
-          </property>
-          <property name="checked">
-           <bool>false</bool>
-          </property>
-          <property name="autoExclusive">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QRadioButton" name="rb_delay_asTyped">
-          <property name="whatsThis">
-           <string>configure delays between keystrokes: Remember delays as they had been typed while the macro definition process</string>
-          </property>
-          <property name="styleSheet">
-           <string notr="true">font: 10pt ; color:  green;</string>
-          </property>
-          <property name="text">
-           <string>as typed</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QLabel" name="txtBuffer">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="geometry">
-        <rect>
-         <x>300</x>
-         <y>100</y>
-         <width>0</width>
-         <height>0</height>
-        </rect>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="contextMenuPolicy">
-        <enum>Qt::NoContextMenu</enum>
-       </property>
-       <property name="toolTip">
-        <string notr="true"/>
-       </property>
-       <property name="toolTipDuration">
-        <number>0</number>
-       </property>
-       <property name="statusTip">
-        <string notr="true"/>
-       </property>
-       <property name="whatsThis">
-        <string notr="true"/>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Plain</enum>
-       </property>
-       <property name="lineWidth">
-        <number>0</number>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="textFormat">
-        <enum>Qt::PlainText</enum>
-       </property>
-       <property name="indent">
-        <number>0</number>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::NoTextInteraction</set>
-       </property>
-      </widget>
       <zorder>pteMacroComment</zorder>
-      <zorder>layoutWidget</zorder>
->>>>>>> 450e80a... handle specials in firmware upgrade: Detection of correct version
       <zorder>layoutWidget1</zorder>
-      <zorder>layoutWidget_delay</zorder>
+      <zorder>layoutWidget</zorder>
       <zorder>pteMacroText</zorder>
       <zorder>layoutWidget_2</zorder>
       <zorder>lbl_macro</zorder>


### PR DESCRIPTION
This PR is the first try to fix #97 . I Think, it should be marked as WiP and used carefully.
The K70 Lux should be detected correctly now (reason for #97).

One problem remains, which i cannot solve without more details:
The Firmware-list in FIRMWARE and that one in fwupgradedialog.cpp still differ.
fwupgradedialog.cpp checks before uploading, if it has the right file. it does so by checking for the hard coded (!!!) productIDs against  words 0x102, 0x104 and 0x106 in the firmware file loaded.
Here we should use the product ID given by the daemon now (it is a bit unsecure, because it may be manipulated by patching the file. So I did not implement it by now).

Here the problem mentioned: Some known hardware IDs are not in the one, some not in the other list.
If you reviewers agree, we should 
- test the PR by some of the users waiting for #97 
- publish the PR in testing, maybe with some more debugging info in fwupgradedialog.cpp
- wait for comments of other users.

Currently I'm thinking about a dialog you give a productID and get as answer what the client thinks what hardware, model (type), firmware-file and version number it detects and the reasons why.
Maybe the next days...

Happy easter!
