### PR TITLE
Add an Info about storage for QSettings objects

### DIFF
--- a/src/ckb/ckbsettings.cpp
+++ b/src/ckb/ckbsettings.cpp
@@ -25,6 +25,7 @@ static QSettings* globalSettings(){
             globalThread = new QThread;
             globalThread->start();
             _globalSettings = new QSettings;
+            qInfo() << "Path  to settings is" << _globalSettings->fileName();
             _globalSettings->moveToThread(globalThread);
         }
     }


### PR DESCRIPTION
Maybe it helps to find the bug in losing config info on some macOS versions (as in #67).
Usage: When installed, open the ckb GUI in a terminal. 
You should find an output like 
```
lutz@Mainfrix ~/Projekte/ckb-next $ ckb
Path  to settings is "/home/lutz/.config/ckb/ckb.conf"
Scanning  "/usr/lib/ckb-animations/ckb-gradient"
...
```