### PR TITLE
Define qInfo and others for Qt Version < 5.5

### DIFF
--- a/ckb.pro
+++ b/ckb.pro
@@ -1,5 +1,5 @@
-lessThan(QT_VERSION, 5.0) {
-    error("ckb requires at least Qt 5.0!")
+lessThan(QT_VERSION, 5.2) {
+    error("ckb requires at least Qt 5.2!")
 }
 
 TEMPLATE = subdirs

--- a/src/ckb/ckbsettings.cpp
+++ b/src/ckb/ckbsettings.cpp
@@ -17,6 +17,13 @@ QMutex settingsMutex(QMutex::Recursive), settingsCacheMutex(QMutex::Recursive);
 #define lockMutexStatic2    QMutexLocker locker2(&settingsMutex)
 #define lockMutexCache      QMutexLocker locker(&settingsCacheMutex)
 
+#if QT_VERSION < QT_VERSION_CHECK(5, 5, 0)
+#define qInfo       qDebug
+#define qWarning    qDebug
+#define qFatal      qDebug
+#define qCritical   qDebug
+#endif
+
 static QSettings* globalSettings(){
     if(!_globalSettings){
         lockMutexStatic;


### PR DESCRIPTION
We should add this to master branch also.

With this fix 4 definitions are implemented
to handle qWarning, qInfo, qCritical and qFatal.
All 4 functions are not know in Qt < 5.5 so comiplation will fail.
The functions are mapped via #defines to qDebug.

When testing that, another error occured with Qt 5.1,
because QCommandLineParser is not know in older versions.

So ckb.pro was updated to demand Qt5.2 at least.