### PR TITLE
Fix init bug for indicator-keys

### DIFF
--- a/src/ckb/kb.cpp
+++ b/src/ckb/kb.cpp
@@ -418,7 +418,7 @@ void Kb::frameUpdate(){
     cmd.write(QString("\n@%1 ").arg(notifyNumber).toLatin1());
     bind->update(cmd, changed);
     cmd.write(" ");
-    perf->update(cmd, changed);
+    perf->update(cmd, notifyNumber, changed);
     cmd.write("\n");
     cmd.flush();
 }

--- a/src/ckb/kbperf.cpp
+++ b/src/ckb/kbperf.cpp
@@ -370,7 +370,7 @@ void KbPerf::angleSnap(bool newAngleSnap){
     _needsUpdate = _needsSave = true;
 }
 
-void KbPerf::update(QFile& cmd, bool force, bool saveCustomDpi){
+void KbPerf::update(QFile& cmd, int notifyNumber, bool force, bool saveCustomDpi){
     if(!force && !_needsUpdate)
         return;
     emit settingsUpdated();
@@ -408,7 +408,7 @@ void KbPerf::update(QFile& cmd, bool force, bool saveCustomDpi){
         cmd.write(output);
     }
     // Enable indicator notifications
-    cmd.write(" inotify all");
+    cmd.write(QString("\n@%1 inotify all").arg(notifyNumber).toLatin1());
     // Set indicator state
     const char* iNames[HW_I_COUNT] = { "num", "caps", "scroll" };
     for(int i = 0; i < HW_I_COUNT; i++){

--- a/src/ckb/kbperf.h
+++ b/src/ckb/kbperf.h
@@ -109,7 +109,7 @@ public:
 
     // Updates settings to the driver. Write "mode %d" first. Disable saveCustomDpi when writing a hardware profile or other permanent storage.
     // By default, nothing will be written unless the settings have changed. Use force = true or call setNeedsUpdate() to override.
-    void        update(QFile& cmd, bool force = false, bool saveCustomDpi = true);
+    void        update(QFile& cmd, int notifyNumber, bool force = false, bool saveCustomDpi = true);
     inline void setNeedsUpdate()        { _needsUpdate = true; }
 
     // Get indicator status to send to KbLight

--- a/src/ckb/kperfwidget.cpp
+++ b/src/ckb/kperfwidget.cpp
@@ -3,6 +3,10 @@
 #include "modeselectdialog.h"
 #include <cmath>
 
+///
+/// \brief KPerfWidget::KPerfWidget sets up the UI for Keyboard Performace panel
+/// \param parent
+///
 KPerfWidget::KPerfWidget(QWidget *parent) :
     QWidget(parent),
     ui(new Ui::KPerfWidget)
@@ -51,10 +55,20 @@ KPerfWidget::KPerfWidget(QWidget *parent) :
     k95Widgets << ui->modeBox << ui->modeColorOn << ui->modeColorOff << ui->macroBox << ui->macroColorOn << ui->macroColorOff << ui->k95Label1 << ui->k95Label2 << ui->k95Label3 << ui->k95Label4 << ui->k95Label5 << ui->k95Label6 << ui->k95Line << ui->k95Spacer;
 }
 
+///
+/// \brief KPerfWidget::~KPerfWidget nothing unusual - just delete the ui object
+///
 KPerfWidget::~KPerfWidget(){
     delete ui;
 }
 
+///
+/// \brief KPerfWidget::raw2Mode return hardware mode depending on setiings in \a sw_enable and \a hw_enable
+/// \param sw_enable
+/// \param hw_enable
+/// \return the mode of operation for key-coloring and separate indicators.
+/// \see KPerfWidget::mode2Raw for details.
+///
 KPerfWidget::HwMode KPerfWidget::raw2Mode(bool sw_enable, i_hw hw_enable){
     if(sw_enable){
         if(hw_enable == KbPerf::NORMAL)
@@ -69,6 +83,20 @@ KPerfWidget::HwMode KPerfWidget::raw2Mode(bool sw_enable, i_hw hw_enable){
     }
 }
 
+///
+/// \brief KPerfWidget::mode2Raw Set values of sw_enable and hw_enable to hte value corresponding to input var mode
+/// \param [IN] mode
+/// \param [OUT] sw_enable
+/// \param [OUT] hw_enable
+/// mode determines how colors at a key and separate indicators should be handled:
+/// Mode | sw | hw
+/// _ | _ | _
+/// NORMAL | No color change at the key | use the separate indicator depending on key state
+/// ALWAYS_ON | No color change at the key | switch on separate indicator
+/// ALWAYS_OFF | No color change at the key | switch off separate indicator
+/// RGB | use color change at the key depending on color sliders | switch off separate indicator
+/// BOTH | use color change at the key depending on color sliders | use the separate indicator depending on key state
+///
 void KPerfWidget::mode2Raw(HwMode mode, bool& sw_enable, i_hw& hw_enable){
     switch(mode){
     case NORMAL:

--- a/src/ckb/kperfwidget.h
+++ b/src/ckb/kperfwidget.h
@@ -43,6 +43,12 @@ private:
         BOTH
     };
     HwMode raw2Mode(bool sw_enable, i_hw hw_enable);
+
+    ///
+    /// \brief KPerfWidget::mode2Raw Set values of sw_enable and hw_enable to hte value corresponding to input var mode
+    /// \param [IN] mode
+    /// \param [OUT] sw_enable
+    /// \param [OUT] hw_enable
     void mode2Raw(HwMode mode, bool& sw_enable, i_hw& hw_enable);
 
     struct IndicatorUi {


### PR DESCRIPTION
Applying it to master also, because it's a bug fix.

After a reboot of the GUI, the indicator keys have only responded
to settings in the Performance tab when one of the settings
has been changed.

The reason for this is in the initialization sequence to the daemon.
With the inotify command executed here,
the Notifychannel must obviously be preceded.

On the occasion a few methods were commented
according to doxygen standard.
Although they had nothing to do with the error,
they were analyzed during debugging.