### PR TITLE
Adding a segment for linux troubleshooting for a solution for F26 on …

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,10 @@ read [this Arch Linux thread](https://bbs.archlinux.org/viewtopic.php?id=214147)
 
 If you're using **Unity** and the tray icon doesn't appear correctly, run `sudo apt-get install libappindicator-dev`. Then reinstall ckb.
 
+#### Fedora 26 Color Changer Freeze Fix
+
+If you're running Fedora 26, a working solution for the color changer freezing issue is to install qt5ct `dnf install qt5ct` then modify your /etc/environment file to contain the line `QT_QPA_PLATFORMTHEME=qt5ct`
+
 ### OS X/macOS
 
 - **“ckb.pkg” can’t be opened because it is from an unidentified developer**


### PR DESCRIPTION
I just added a small section to README.md for a known working fix for the QT 5.7.x bug on a Fedora 26 installation. Should work for other distros but that is unverified (by myself) at the time.