### PR TITLE
Explicitly request signed char.

### DIFF
--- a/src/ckb/ckb.pro
+++ b/src/ckb/ckb.pro
@@ -11,6 +11,12 @@ QMAKE_LIBS_OPENGL =
 QMAKE_CFLAGS += -Wno-unused-parameter
 QMAKE_CXXFLAGS += -Wno-unused-parameter
 
+# Explicitly require signed char to fix issues on ARM, where char is
+# unsigned by default for performance reasons, compared to x86's
+# default-signed char.
+QMAKE_CFLAGS += -fsigned-char
+QMAKE_CXXFLAGS += -fsigned-char
+
 # Output path
 macx {
     DESTDIR = $$PWD/../..


### PR DESCRIPTION
The ckb-daemon code seems to implicitly assume char is signed,
which, while accurate for x86 for performance reasons, is
unspecified by the C standard. This breaks the code on ARM chips
like the Raspberry Pi where char is unsigned by default.

Therefore, explicitly request signed chars to GCC/Clang.