### PR TITLE
set QT_BEARER_POLL_TIMEOUT to -1 before instantiating QNetworkAccessM…

### DIFF
--- a/src/ckb/kbfirmware.cpp
+++ b/src/ckb/kbfirmware.cpp
@@ -14,6 +14,9 @@ KbFirmware::FW::FW() : fwVersion(0.f), ckbVersion(0.f) {}
 KbFirmware::KbFirmware() :
     lastCheck(0), lastFinished(0), networkManager(0), tableDownload(0), hasGPG(UNKNOWN)
 {
+    // Disable bearer polling. This corrects an issue with latency spikes when
+    // using WiFi. The problem and this workaround, are described here:
+    // https://lostdomain.org/2017/06/17/qt-qnetworkaccessmanager-causing-latency-spikes-on-wifi/
     qputenv("QT_BEARER_POLL_TIMEOUT", QByteArray::number(-1));
     networkManager = new QNetworkAccessManager();
 }

--- a/src/ckb/kbfirmware.cpp
+++ b/src/ckb/kbfirmware.cpp
@@ -15,7 +15,7 @@ KbFirmware::KbFirmware() :
     lastCheck(0), lastFinished(0), networkManager(0), tableDownload(0), hasGPG(UNKNOWN)
 {
     // Disable bearer polling. This corrects an issue with latency spikes when
-    // using WiFi. The problem and this workaround, are described here:
+    // using WiFi. The problem and workaround are described here:
     // https://lostdomain.org/2017/06/17/qt-qnetworkaccessmanager-causing-latency-spikes-on-wifi/
     qputenv("QT_BEARER_POLL_TIMEOUT", QByteArray::number(-1));
     networkManager = new QNetworkAccessManager();

--- a/src/ckb/kbfirmware.cpp
+++ b/src/ckb/kbfirmware.cpp
@@ -14,6 +14,7 @@ KbFirmware::FW::FW() : fwVersion(0.f), ckbVersion(0.f) {}
 KbFirmware::KbFirmware() :
     lastCheck(0), lastFinished(0), networkManager(0), tableDownload(0), hasGPG(UNKNOWN)
 {
+    qputenv("QT_BEARER_POLL_TIMEOUT", QByteArray::number(-1));
     networkManager = new QNetworkAccessManager();
 }
 


### PR DESCRIPTION
I believe the root cause of issue #42 is the one described here:
https://lostdomain.org/2017/06/17/qt-qnetworkaccessmanager-causing-latency-spikes-on-wifi/
This implements the suggested workaround.

I've tested this change on OSX and it seems to stop the latency spikes.