### PR TITLE
Reduce ckb CPU usage when mute state polling is not necessary

### DIFF
--- a/src/ckb/ckb.pro
+++ b/src/ckb/ckb.pro
@@ -46,6 +46,11 @@ system(pkg-config --exists x11) {
     LIBS += -lX11
     DEFINES += USE_LIBX11
 }
+# Use libpulse for audio playback mute detection
+system(pkg-config --exists libpulse) {
+    LIBS += -lpulse
+    DEFINES += USE_LIBPULSE
+}
 }
 
 SOURCES += main.cpp\

--- a/src/ckb/media_linux.cpp
+++ b/src/ckb/media_linux.cpp
@@ -1,34 +1,142 @@
 #ifndef __APPLE__
 
 #include <QDateTime>
-#include <QProcess>
+#include <QMutex>
+#ifdef USE_LIBPULSE
+#include <pulse/context.h>
+#include <pulse/introspect.h>
+#include <pulse/subscribe.h>
+#include <pulse/thread-mainloop.h>
+#endif
 #include "media.h"
 
-static QProcess muteProcess;
+static muteState lastKnown = UNKNOWN;
+
+#ifdef USE_LIBPULSE
+static pa_context* paContext = nullptr; //Context for communicating with Pulse Audio.
+static quint64 reconnectTime = 0; //Time (in MSecs since epoch) to attempt reconnect.
+static QString defaultSink; //Name of sink being checked if muted.
+static QMutex mutex;
+
+static bool CheckPAOperation(pa_operation* operation){
+    if(operation == nullptr)
+        return false;
+
+    pa_operation_unref(operation);
+    return true;
+}
+
+static void SinkCallback(pa_context* context, const pa_sink_info* info, int eol, void* data){
+    QMutexLocker locker(&mutex);
+
+    if(info == nullptr || info->name != defaultSink)
+        return;
+
+    lastKnown = info->mute ? MUTED : UNMUTED;
+}
+
+static void ServerCallback(pa_context* context, const pa_server_info* info, void* data){
+    QMutexLocker locker(&mutex);
+
+    //Keep track of the default sink. This is the only one checked if muted. If
+    //the user changes this, SinkCallback will be called afterwards
+    //automatically. This will then check if the new default sink is muted.
+    defaultSink = info->default_sink_name;
+}
+
+static void SubscribeCallback(pa_context* context, pa_subscription_event_type_t type, uint32_t index, void* data){
+    const pa_subscription_event_type_t eventFacility = static_cast<pa_subscription_event_type_t>(type & PA_SUBSCRIPTION_EVENT_FACILITY_MASK);
+    if(eventFacility == PA_SUBSCRIPTION_EVENT_SINK){
+        //A sink was added or changed in some way. Get new info to see if it
+        //was muted.
+        if(!CheckPAOperation(pa_context_get_sink_info_by_index(context, index, SinkCallback, nullptr)))
+            qWarning("getMuteState(): pa_context_get_sink_info_by_index() error");
+    }
+    else if(eventFacility ==  PA_SUBSCRIPTION_EVENT_SERVER){
+        //Server settings were modified. Get new info to see if default sink
+        //was changed.
+        if(!CheckPAOperation(pa_context_get_server_info(context, ServerCallback, nullptr)))
+            qWarning("getMuteState(): pa_context_get_server_info() error");
+    }
+}
+
+static void ContextStateCallback(pa_context* context, void* data){
+    if(context != paContext)
+        return;
+
+    pa_context_state_t state = pa_context_get_state(context);
+    if(state == PA_CONTEXT_READY){
+        pa_context_set_subscribe_callback(context, SubscribeCallback, nullptr);
+        if(!CheckPAOperation(pa_context_subscribe(context,
+                                                  static_cast<pa_subscription_mask_t>(PA_SUBSCRIPTION_MASK_SINK |
+                                                                                      PA_SUBSCRIPTION_MASK_SERVER),
+                                                  nullptr,
+                                                  nullptr)))
+            qWarning("getMuteState(): pa_context_subscribe() error");
+
+        //Find initial default device.
+        if(!CheckPAOperation(pa_context_get_server_info(context, ServerCallback, nullptr)))
+            qWarning("getMuteState(): pa_context_get_server_info() error");
+
+        //Find initial mute state.
+        if(!CheckPAOperation(pa_context_get_sink_info_list(context, SinkCallback, nullptr)))
+            qWarning("getMuteState(): pa_context_get_sink_info_list() error");
+    }
+    else if(state == PA_CONTEXT_FAILED || state == PA_CONTEXT_TERMINATED){
+        QMutexLocker locker(&mutex);
+
+        //Either we could not connect to the server or the on going connection
+        //was dropped.
+        if(paContext != nullptr){
+            pa_context_unref(paContext);
+            paContext = nullptr;
+
+            //Try to reconnect again shortly.
+            reconnectTime = QDateTime::currentMSecsSinceEpoch() + 1000;
+        }
+    }
+}
+
+#endif
 
 muteState getMuteState(){
-    // Get default sink mute state from pulseaudio
-    static muteState lastKnown = UNKNOWN;
-    static quint64 lastTime = 0;
-    // Instead of running a command to check the state and waiting for it to finish, run the command now but wait to check it until the next frame
-    // (locking up the GUI thread is bad)
-    if(lastTime > 0 && muteProcess.state() == QProcess::NotRunning){
-        if(muteProcess.exitCode() != 0)
-            lastKnown = UNKNOWN;
-        QString output = muteProcess.readLine().trimmed();
-        if(output == "yes")
-            lastKnown = MUTED;
-        else if(output == "no")
-            lastKnown = UNMUTED;
+#ifdef USE_LIBPULSE
+    static pa_threaded_mainloop* mainLoop = nullptr;
+
+    QMutexLocker locker(&mutex);
+
+    //Setup main loop thread used for communicating with Pulse Audio. All
+    //communication is done asynchronously.
+    if(mainLoop == nullptr){
+        mainLoop = pa_threaded_mainloop_new();
+        if(mainLoop == nullptr)
+            return lastKnown;
+
+        if(pa_threaded_mainloop_start(mainLoop) != 0){
+            pa_threaded_mainloop_free(mainLoop);
+            mainLoop = nullptr;
+            return lastKnown;
+        }
     }
-    quint64 time = QDateTime::currentMSecsSinceEpoch();
-    if(time - lastTime < 33)
-        // Don't run it than 30 times per second
-        return lastKnown;
-    lastTime = time;
-    if(muteProcess.state() == QProcess::NotRunning)
-        // Shamelessly taken from pulseaudio-ctl
-        muteProcess.start("sh", QStringList() << "-c" << "pacmd list-sinks|grep -A 15 '* index'|awk '/muted:/{ print $2 }'");
+
+    //Connect to the local Pulse Audio server. It's usually running but a
+    //reconnect is attempted periodically whenever the connection fails or is
+    //terminated.
+    if(paContext == nullptr && QDateTime::currentMSecsSinceEpoch() >= reconnectTime){
+        pa_threaded_mainloop_lock(mainLoop);
+        {
+            pa_mainloop_api* api = pa_threaded_mainloop_get_api(mainLoop);
+            Q_ASSERT(api != nullptr);
+
+            paContext = pa_context_new(api, "QPulse");
+            Q_ASSERT(paContext != nullptr);
+            pa_context_set_state_callback(paContext, &ContextStateCallback, nullptr);
+            pa_context_connect(paContext, nullptr, PA_CONTEXT_NOFAIL, nullptr);
+        }
+        pa_threaded_mainloop_unlock(mainLoop);
+    }
+#endif
+
     return lastKnown;
 }
 

--- a/src/ckb/media_linux.cpp
+++ b/src/ckb/media_linux.cpp
@@ -14,7 +14,7 @@ static muteState lastKnown = UNKNOWN;
 
 #ifdef USE_LIBPULSE
 static pa_context* paContext = nullptr; //Context for communicating with Pulse Audio.
-static quint64 reconnectTime = 0; //Time (in MSecs since epoch) to attempt reconnect.
+static qint64 reconnectTime = 0; //Time (in MSecs since epoch) to attempt reconnect.
 static QString defaultSink; //Name of sink being checked if muted.
 static QMutex mutex;
 


### PR DESCRIPTION
Selecting a mode with no animations and minimizing the GUI to the system tray constantly uses ~4.3%-6.6% CPU according to `top`. This minor change reduces it to ~0.3%. I didn't notice anything broken from the change but I only tested it with a STRAFE keyboard on Linux.