### PR TITLE
Correct DPI indicator LED issues for the Glaive.

### DIFF
--- a/src/ckb-daemon/dpi.c
+++ b/src/ckb-daemon/dpi.c
@@ -99,6 +99,8 @@ int updatedpi(usbdevice* kb, int force){
 
     // Send X/Y DPIs
     for(int i = 0; i < DPI_COUNT; i++){
+        if (newdpi->x[i] == lastdpi->x[i] && newdpi->y[i] == lastdpi->y[i])
+            continue;
         uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0xd0, 0 };
         data_pkt[2] |= i;
         *(ushort*)(data_pkt + 5) = newdpi->x[i];
@@ -108,14 +110,27 @@ int updatedpi(usbdevice* kb, int force){
     }
 
     // Send settings
-    uchar data_pkt[4][MSG_SIZE] = {
-        { 0x07, 0x13, 0x05, 0, newdpi->enabled },
-        { 0x07, 0x13, 0x02, 0, newdpi->current },
-        { 0x07, 0x13, 0x03, 0, newdpi->lift },
-        { 0x07, 0x13, 0x04, 0, newdpi->snap, 0x05 }
-    };
-    if(!usbsend(kb, data_pkt[0], 4))
-        return -2;
+    if (newdpi->enabled != lastdpi->enabled) {
+        uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0x05, 0, newdpi->enabled };
+        if(!usbsend(kb, data_pkt, 1))
+            return -2;
+    }
+    if (newdpi->current != lastdpi->current) {
+        uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0x02, 0, newdpi->current };
+        if(!usbsend(kb, data_pkt, 1))
+            return -2;
+    }
+    if (newdpi->lift != lastdpi->lift) {
+        uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0x03, 0, newdpi->lift };
+        if(!usbsend(kb, data_pkt, 1))
+            return -2;
+    }
+    if (newdpi->snap != lastdpi->snap) {
+        uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0x04, 0, newdpi->snap, 0x05 };
+        if(!usbsend(kb, data_pkt, 1))
+            return -2;
+    }
+
     // Finished
     memcpy(lastdpi, newdpi, sizeof(dpiset));
     return 0;

--- a/src/ckb-daemon/led_mouse.c
+++ b/src/ckb-daemon/led_mouse.c
@@ -28,13 +28,17 @@ int updatergb_mouse(usbdevice* kb, int force){
         return 0;
     lastlight->forceupdate = newlight->forceupdate = 0;
 
+    // Prevent writing to DPI LEDs or non-existent LED zones for the Glaive.
+    int num_zones = IS_GLAIVE(kb) ? 3 : N_MOUSE_ZONES;
     // Send the RGB values for each zone to the mouse
     uchar data_pkt[2][MSG_SIZE] = {
-        { 0x07, 0x22, N_MOUSE_ZONES, 0x01, 0 }, // RGB colors
+        { 0x07, 0x22, num_zones, 0x01, 0 }, // RGB colors
         { 0x07, 0x05, 0x02, 0 }                 // Lighting on/off
     };
     uchar* rgb_data = &data_pkt[0][4];
     for(int i = 0; i < N_MOUSE_ZONES; i++){
+        if (IS_GLAIVE(kb) && (i == 2 || i == 3 || i == 4))
+	    continue;
         *rgb_data++ = i + 1;
         *rgb_data++ = newlight->r[LED_MOUSE + i];
         *rgb_data++ = newlight->g[LED_MOUSE + i];

--- a/src/ckb-daemon/led_mouse.c
+++ b/src/ckb-daemon/led_mouse.c
@@ -37,7 +37,7 @@ int updatergb_mouse(usbdevice* kb, int force){
     };
     uchar* rgb_data = &data_pkt[0][4];
     for(int i = 0; i < N_MOUSE_ZONES; i++){
-        if (IS_GLAIVE(kb) && (i == 2 || i == 3 || i == 4))
+        if (IS_GLAIVE(kb) && i != 0 && i != 1 && i != 5)
 	    continue;
         *rgb_data++ = i + 1;
         *rgb_data++ = newlight->r[LED_MOUSE + i];

--- a/src/ckb/kbbind.cpp
+++ b/src/ckb/kbbind.cpp
@@ -88,7 +88,7 @@ void KbBind::save(CkbSettings& settings){
         SGroup group(settings, "Keys");
         foreach(QString key, _bind.keys()){
             KeyAction* act = _bind.value(key);
-            if(act && act->value() != KeyAction::defaultAction(key))
+            if(act && act->value() != KeyAction::defaultAction(key, devParent()->model()))
                 settings.setValue(key, act->value());
         }
     }
@@ -137,14 +137,23 @@ void KbBind::map(const KeyMap& map){
     emit layoutChanged();
 }
 
+KeyAction* KbBind::bindAction(const QString& key) {
+  if(!_bind.contains(key)) return _bind[key] = new KeyAction(KeyAction::defaultAction(key, devParent()->model()), this);
+  return _bind[key];
+}
+
 QString KbBind::action(const QString& key){
     QString rKey = globalRemap(key);
     return bindAction(rKey)->value();
 }
 
-QString KbBind::defaultAction(const QString& key){
+QString KbBind::defaultAction(const QString& key, KeyMap::Model model){
     QString rKey = globalRemap(key);
-    return KeyAction::defaultAction(rKey);
+    return KeyAction::defaultAction(rKey, model);
+}
+
+QString KbBind::defaultAction(const QString& key){
+  return defaultAction(key, devParent()->model());
 }
 
 QString KbBind::friendlyName(const QString& key){

--- a/src/ckb/kbbind.h
+++ b/src/ckb/kbbind.h
@@ -57,7 +57,8 @@ public:
     // Action for a given key. Use KeyAction(action) to get info about it.
     QString         action(const QString& key);
     // Default action for a key.
-    static QString  defaultAction(const QString& key);
+    QString         defaultAction(const QString& key);
+    static QString  defaultAction(const QString& key, KeyMap::Model model);
 
     // Friendly name for a key, taking into account the global key remap
     QString friendlyName(const QString& key);
@@ -114,7 +115,7 @@ private:
     inline Kb*      devParent()     const   { return _devParent; }
     inline KbMode*  modeParent()    const   { return (KbMode*)parent(); }
 
-    inline KeyAction* bindAction(const QString& key)    { if(!_bind.contains(key)) return _bind[key] = new KeyAction(KeyAction::defaultAction(key), this); return _bind[key]; }
+    KeyAction* bindAction(const QString& key);
 
     static QHash<QString, QString>  _globalRemap;
     static quint64                  globalRemapTime;

--- a/src/ckb/kbperf.cpp
+++ b/src/ckb/kbperf.cpp
@@ -311,6 +311,8 @@ void KbPerf::dpiUp(){
     do {
         idx++;
         if(idx >= DPI_COUNT)
+            idx = SNIPER + 1;
+        if(idx == curDpiIdx())
             return;
     } while(!dpiOn[idx]);
     curDpiIdx(idx);
@@ -321,6 +323,8 @@ void KbPerf::dpiDown(){
     do {
         idx--;
         if(idx <= SNIPER)
+            idx = DPI_COUNT - 1;
+	if(idx == curDpiIdx())
             return;
     } while(!dpiOn[idx]);
     curDpiIdx(idx);

--- a/src/ckb/kbperf.cpp
+++ b/src/ckb/kbperf.cpp
@@ -311,6 +311,27 @@ void KbPerf::dpiUp(){
     do {
         idx++;
         if(idx >= DPI_COUNT)
+            return;
+    } while(!dpiOn[idx]);
+    curDpiIdx(idx);
+}
+
+void KbPerf::dpiDown(){
+    int idx = curDpiIdx();
+    do {
+        idx--;
+        if(idx <= SNIPER)
+            return;
+    } while(!dpiOn[idx]);
+    curDpiIdx(idx);
+}
+
+// dpiCycleUp will loop to lowest setting after passing the highest.
+void KbPerf::dpiCycleUp(){
+    int idx = curDpiIdx();
+    do {
+        idx++;
+        if(idx >= DPI_COUNT)
             idx = SNIPER + 1;
         if(idx == curDpiIdx())
             return;
@@ -318,7 +339,7 @@ void KbPerf::dpiUp(){
     curDpiIdx(idx);
 }
 
-void KbPerf::dpiDown(){
+void KbPerf::dpiCycleDown(){
     int idx = curDpiIdx();
     do {
         idx--;

--- a/src/ckb/kbperf.h
+++ b/src/ckb/kbperf.h
@@ -62,6 +62,8 @@ public:
     inline void     curDpiIdx(int newIdx) { curDpi(dpi(newIdx)); }
     void            dpiUp();
     void            dpiDown();
+    void            dpiCycleUp();
+    void            dpiCycleDown();
     // DPI stages enabled (default all). Disabled stages will be bypassed when invoking dpiUp/dpiDown (but not any other functions).
     inline bool     dpiEnabled(int index) const             { return dpiOn[index]; }
     inline void     dpiEnabled(int index, bool newEnabled)  { if(index <= 0) return; dpiOn[index] = newEnabled; _needsUpdate = _needsSave = true; }

--- a/src/ckb/keyaction.cpp
+++ b/src/ckb/keyaction.cpp
@@ -104,6 +104,10 @@ QString KeyAction::friendlyName(const KeyMap& map) const {
         // Split off custom parameters (if any)
         int level = parts[1].split("+")[0].toInt();
         switch(level){
+        case DPI_CYCLE_UP:
+            return "DPI cycle up";
+        case DPI_CYCLE_DOWN:
+            return "DPI cycle down";
         case DPI_UP:
             return "DPI up";
         case DPI_DOWN:
@@ -279,6 +283,16 @@ void KeyAction::keyEvent(KbBind* bind, bool down){
         KbPerf* perf = bind->perf();
         int level = parts[1].split("+")[0].toInt();
         switch(level){
+        case DPI_CYCLE_UP:
+            if(!down)
+                return;
+            perf->dpiCycleUp();
+            break;
+        case DPI_CYCLE_DOWN:
+            if(!down)
+                return;
+            perf->dpiCycleDown();
+            break;
         case DPI_UP:
             if(!down)
                 return;

--- a/src/ckb/keyaction.cpp
+++ b/src/ckb/keyaction.cpp
@@ -41,7 +41,7 @@ KeyAction::~KeyAction(){
     }
 }
 
-QString KeyAction::defaultAction(const QString& key){
+QString KeyAction::defaultAction(const QString& key, KeyMap::Model model){
     // G1-G18 are unbound by default
     if(key.length() >= 2 && key[0] == 'g'
 		&& ((key.length() == 2 && key[1] >= '0' && key[1] <= '9')
@@ -66,8 +66,13 @@ QString KeyAction::defaultAction(const QString& key){
     if(key == "lock")
         return "$lock:0";
     // DPI buttons
-    if(key == "dpiup")
-        return "$dpi:-2";
+    if(key == "dpiup"){
+        if(model == KeyMap::HARPOON ||
+	   model == KeyMap::GLAIVE){
+	    return "$dpi:-4";
+        }
+	return "$dpi:-2";
+    }
     if(key == "dpidn")
         return "$dpi:-1";
     if(key == "sniper")

--- a/src/ckb/keyaction.h
+++ b/src/ckb/keyaction.h
@@ -24,7 +24,7 @@ public:
     // No action
     static inline QString   noAction()    { return ""; }
     // Default action (usually the same as the key name, but not always)
-    static QString          defaultAction(const QString& key);
+    static QString          defaultAction(const QString& key, KeyMap::Model model);
 
     // Friendly action name
     QString friendlyName(const KeyMap& map) const;

--- a/src/ckb/keyaction.h
+++ b/src/ckb/keyaction.h
@@ -103,6 +103,7 @@ public:
     const static int MODE_PREV_WRAP = -4, MODE_NEXT_WRAP = -3;
     static QString  modeAction(int mode);
     // DPI action. 0 for sniper, 1 for first DPI, etc
+    const static int DPI_CYCLE_UP = -4, DPI_CYCLE_DOWN = -3;
     const static int DPI_UP = -2, DPI_DOWN = -1;
     const static int DPI_SNIPER = 0, DPI_CUSTOM = 6;
     static QString  dpiAction(int level, int customX = 0, int customY = 0);

--- a/src/ckb/keywidget.cpp
+++ b/src/ckb/keywidget.cpp
@@ -399,7 +399,7 @@ void KeyWidget::paintEvent(QPaintEvent*){
             }
             // Pick color based on key function
             QString bind = _bindMap.value(key.name);
-            QString def = KbBind::defaultAction(key.name);
+            QString def = KbBind::defaultAction(key.name, model);
             if(bind.isEmpty())
                 // Unbound - red
                 decPainter.setPen(QColor(255, 136, 136));

--- a/src/ckb/rebindwidget.cpp
+++ b/src/ckb/rebindwidget.cpp
@@ -3,7 +3,7 @@
 #include "ui_rebindwidget.h"
 #include <qdebug.h>     // lae.
 
-static const int DPI_OFFSET = -KeyAction::DPI_UP + 1;
+static const int DPI_OFFSET = -KeyAction::DPI_CYCLE_UP + 1;
 static const int DPI_CUST_IDX = KeyAction::DPI_CUSTOM + DPI_OFFSET;
 
 RebindWidget::RebindWidget(QWidget *parent) :
@@ -108,7 +108,7 @@ void RebindWidget::setBind(KbBind* newBind, KbProfile* newProfile){
         const KbPerf* perf = bind->perf();
         for(int i = 0; i < KbPerf::DPI_COUNT; i++){
             bool sniper = (i == 0);
-            int boxIdx = i + 3;
+            int boxIdx = i + DPI_OFFSET;
             QPoint dpi = perf->dpi(i);
             QString text = tr(sniper ? "Sniper:\t%1 x %2" : "%3:\t%1 x %2").arg(dpi.x()).arg(dpi.y());
             if(!sniper) text = text.arg(i);

--- a/src/ckb/rebindwidget.cpp
+++ b/src/ckb/rebindwidget.cpp
@@ -72,7 +72,7 @@ void RebindWidget::setBind(KbBind* newBind, KbProfile* newProfile){
     // Use the K95 map as it has all keys
     const KeyMap& map = KeyMap(KeyMap::K95, bind->map().layout());
     foreach(const QString& name, map.byPosition()){
-        KeyAction action(KbBind::defaultAction(name));
+        KeyAction action(bind->defaultAction(name));
         if(action.isNormal() && !modKeys.contains(name) && !fnKeys.contains(name) && !numKeys.contains(name) && !mediaKeys.contains(name) && name != "enter" && name != "tab" && name != "bspace"){
             const Key& pos = map[name];
             QString friendly = pos.friendlyName();

--- a/src/ckb/rebindwidget.ui
+++ b/src/ckb/rebindwidget.ui
@@ -401,6 +401,16 @@
          </item>
          <item>
           <property name="text">
+           <string>(Cycle Up)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>(Cycle Down)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
            <string>(Up)</string>
           </property>
          </item>


### PR DESCRIPTION
This corrects two issues with the DPI LEDs:
1. the DPI LEDs flicker when changing DPIs, and
2. when an animation is running, the DPI LEDs turn on when changing DPIs but then turn off almost immediately.