### PR TITLE
Avoid setting DPI to bad values during modification.

### DIFF
--- a/src/ckb-daemon/dpi.c
+++ b/src/ckb-daemon/dpi.c
@@ -99,6 +99,8 @@ int updatedpi(usbdevice* kb, int force){
 
     // Send X/Y DPIs
     for(int i = 0; i < DPI_COUNT; i++){
+        if (newdpi->x[i] == lastdpi->x[i] && newdpi->y[i] == lastdpi->y[i])
+            continue;
         uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0xd0, 0 };
         data_pkt[2] |= i;
         *(ushort*)(data_pkt + 5) = newdpi->x[i];
@@ -108,14 +110,27 @@ int updatedpi(usbdevice* kb, int force){
     }
 
     // Send settings
-    uchar data_pkt[4][MSG_SIZE] = {
-        { 0x07, 0x13, 0x05, 0, newdpi->enabled },
-        { 0x07, 0x13, 0x02, 0, newdpi->current },
-        { 0x07, 0x13, 0x03, 0, newdpi->lift },
-        { 0x07, 0x13, 0x04, 0, newdpi->snap, 0x05 }
-    };
-    if(!usbsend(kb, data_pkt[0], 4))
-        return -2;
+    if (newdpi->enabled != lastdpi->enabled) {
+        uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0x05, 0, newdpi->enabled };
+        if(!usbsend(kb, data_pkt, 1))
+            return -2;
+    }
+    if (newdpi->current != lastdpi->current) {
+        uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0x02, 0, newdpi->current };
+        if(!usbsend(kb, data_pkt, 1))
+            return -2;
+    }
+    if (newdpi->lift != lastdpi->lift) {
+        uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0x03, 0, newdpi->lift };
+        if(!usbsend(kb, data_pkt, 1))
+            return -2;
+    }
+    if (newdpi->snap != lastdpi->snap) {
+        uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0x04, 0, newdpi->snap, 0x05 };
+        if(!usbsend(kb, data_pkt, 1))
+            return -2;
+    }
+
     // Finished
     memcpy(lastdpi, newdpi, sizeof(dpiset));
     return 0;

--- a/src/ckb-daemon/dpi.c
+++ b/src/ckb-daemon/dpi.c
@@ -100,6 +100,13 @@ int updatedpi(usbdevice* kb, int force){
     if (newdpi->current != lastdpi->current) {
         // Before we switch current DPI stage, set the DPI XY for the new stage
         // if necessary.
+        if ((lastdpi->enabled & 1 << newdpi->current) == 0) {
+            uchar newenabled = lastdpi->enabled | 1 << newdpi->current;
+            uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0x05, 0, newenabled };
+            if(!usbsend(kb, data_pkt, 1))
+                return -2;
+            lastdpi->enabled = newenabled;
+        }
         if (newdpi->x[newdpi->current] != lastdpi->x[newdpi->current] ||
             newdpi->y[newdpi->current] != lastdpi->y[newdpi->current]) {
             uchar data_pkt[MSG_SIZE] = { 0x07, 0x13, 0xd0, 0 };

--- a/src/ckb-daemon/led_mouse.c
+++ b/src/ckb-daemon/led_mouse.c
@@ -28,13 +28,17 @@ int updatergb_mouse(usbdevice* kb, int force){
         return 0;
     lastlight->forceupdate = newlight->forceupdate = 0;
 
+    // Prevent writing to DPI LEDs or non-existent LED zones for the Glaive.
+    int num_zones = IS_GLAIVE(kb) ? 3 : N_MOUSE_ZONES;
     // Send the RGB values for each zone to the mouse
     uchar data_pkt[2][MSG_SIZE] = {
-        { 0x07, 0x22, N_MOUSE_ZONES, 0x01, 0 }, // RGB colors
+        { 0x07, 0x22, num_zones, 0x01, 0 }, // RGB colors
         { 0x07, 0x05, 0x02, 0 }                 // Lighting on/off
     };
     uchar* rgb_data = &data_pkt[0][4];
     for(int i = 0; i < N_MOUSE_ZONES; i++){
+        if (IS_GLAIVE(kb) && (i == 2 || i == 3 || i == 4))
+	    continue;
         *rgb_data++ = i + 1;
         *rgb_data++ = newlight->r[LED_MOUSE + i];
         *rgb_data++ = newlight->g[LED_MOUSE + i];

--- a/src/ckb-daemon/led_mouse.c
+++ b/src/ckb-daemon/led_mouse.c
@@ -37,7 +37,7 @@ int updatergb_mouse(usbdevice* kb, int force){
     };
     uchar* rgb_data = &data_pkt[0][4];
     for(int i = 0; i < N_MOUSE_ZONES; i++){
-        if (IS_GLAIVE(kb) && (i == 2 || i == 3 || i == 4))
+        if (IS_GLAIVE(kb) && i != 0 && i != 1 && i != 5)
 	    continue;
         *rgb_data++ = i + 1;
         *rgb_data++ = newlight->r[LED_MOUSE + i];


### PR DESCRIPTION
This change ensures that, before changing DPI stage, we first set the DPI and enabled flags as necessary. Previously, when changing both DPI stage and the DPI stage settings at the same time (such as during a mode switch), we could set the DPI to some unintentional value, or set it to a disabled stage.

This should correct issue #214.