### PR TITLE
Use an index to represent the current DPI, not a point.

### DIFF
--- a/src/ckb/kb.cpp
+++ b/src/ckb/kb.cpp
@@ -717,7 +717,7 @@ void Kb::readNotify(QString line){
                 idx = 1;
             if(idx >= KbPerf::DPI_COUNT)
                 idx = KbPerf::DPI_COUNT - 1;
-            perf->curDpiIdx(idx);
+            perf->baseDpiIdx(idx);
         } else if(components[2] == "hwlift"){
             // Mouse lift height (1...5)
             if(!_hwProfile || _hwProfile->modeCount() <= mode || mode >= HWMODE_MAX || !hwLoading[mode + 1])

--- a/src/ckb/kbperf.cpp
+++ b/src/ckb/kbperf.cpp
@@ -150,20 +150,20 @@ void KbPerf::load(CkbSettings& settings){
         QColor color = settings.value("6RGB").toString();
         if(color.isValid())
             dpiClr[OTHER] = color;
-	// The current DPI is stored as a point, not an index. If this point
-	// does not exist in the table, we'll use the table entry with index 1.
-        QPoint value = settings.value("Current").toPoint();
-	dpiBaseIdx = 1;
-	// Skip index 0, which is the sniper DPI.
-	for (int i = 1; i < DPI_COUNT; i++) {
-	    if (dpiX[i] == value.x() &&
-		dpiY[i] == value.y() &&
-		dpiOn[i]) {
-	        dpiBaseIdx = i;
-	        break;
-	   }
-	}
-	_curDpi(dpi(dpiBaseIdx));
+        if (settings.contains("CurIdx")) {
+            dpiBaseIdx = settings.value("CurIdx").toInt();
+        } else {
+            // If there isn't a setting for current DPI stage, pick the first
+            // enabled one. Failing that just pick stage 1.
+            dpiBaseIdx = 1;
+            for (int i = 1; i < DPI_COUNT; i++) {
+                if (dpiOn[i]) {
+                    dpiBaseIdx = i;
+                    break;
+                }
+            }	 
+        }
+        _curDpi(dpi(dpiBaseIdx));
     }
     // Read misc. mouse settings
     _liftHeight = (height)settings.value("LiftHeight").toInt();
@@ -222,9 +222,7 @@ void KbPerf::save(CkbSettings& settings){
         }
         settings.setValue("6RGB", dpiClr[OTHER].name(QColor::HexArgb));
 	// Ignore pushed modes when saving current DPI.
-        int curX = dpi(dpiBaseIdx).x();
-	int curY = dpi(dpiBaseIdx).y();
-        settings.setValue("Current", QPoint(curX, curY));
+        settings.setValue("CurIdx", dpiBaseIdx);
     }
     settings.setValue("LiftHeight", _liftHeight);
     settings.setValue("AngleSnap", _angleSnap);

--- a/src/ckb/kbperf.cpp
+++ b/src/ckb/kbperf.cpp
@@ -154,8 +154,11 @@ void KbPerf::load(CkbSettings& settings){
 	// does not exist in the table, we'll use the table entry with index 1.
         QPoint value = settings.value("Current").toPoint();
 	dpiBaseIdx = 1;
-	for (int i = 0; i < DPI_COUNT; i++) {
-	    if (dpiX[i] == value.x() && dpiY[i] == value.y()) {
+	// Skip index 0, which is the sniper DPI.
+	for (int i = 1; i < DPI_COUNT; i++) {
+	    if (dpiX[i] == value.x() &&
+		dpiY[i] == value.y() &&
+		dpiOn[i]) {
 	        dpiBaseIdx = i;
 	        break;
 	   }

--- a/src/ckb/kbperf.cpp
+++ b/src/ckb/kbperf.cpp
@@ -30,7 +30,7 @@ KbPerf::KbPerf(KbMode* parent) :
     dpiClr[6] = QColor(192, 192, 192);
     for(int i = 0; i < DPI_COUNT; i++)
         dpiOn[i] = true;
-    dpiLastIdx = dpiBaseIdx = 3;
+    dpiBaseIdx = 3;
     dpiCurX = dpiX[dpiBaseIdx];
     dpiCurY = dpiY[dpiBaseIdx];
     // Default indicators
@@ -55,7 +55,7 @@ KbPerf::KbPerf(KbMode* parent) :
 }
 
 KbPerf::KbPerf(KbMode* parent, const KbPerf& other) :
-    QObject(parent), dpiCurX(other.dpiCurX), dpiCurY(other.dpiCurY), dpiBaseIdx(other.dpiBaseIdx), dpiLastIdx(other.dpiLastIdx), runningPushIdx(1),
+    QObject(parent), dpiCurX(other.dpiCurX), dpiCurY(other.dpiCurY), dpiBaseIdx(other.dpiBaseIdx), runningPushIdx(1),
     _iOpacity(other._iOpacity), light100Color(other.light100Color), muteNAColor(other.muteNAColor), _dpiIndicator(other._dpiIndicator),
     _liftHeight(other._liftHeight), _angleSnap(other._angleSnap),
     _needsUpdate(true), _needsSave(true) {
@@ -75,7 +75,7 @@ KbPerf::KbPerf(KbMode* parent, const KbPerf& other) :
 }
 
 const KbPerf& KbPerf::operator= (const KbPerf& other){
-    dpiCurX = other.dpiCurX; dpiCurY = other.dpiCurY; dpiBaseIdx = other.dpiBaseIdx; dpiLastIdx = other.dpiLastIdx; runningPushIdx = 1;
+    dpiCurX = other.dpiCurX; dpiCurY = other.dpiCurY; dpiBaseIdx = other.dpiBaseIdx; runningPushIdx = 1;
     _iOpacity = other._iOpacity; light100Color = other.light100Color; muteNAColor = other.muteNAColor; _dpiIndicator = other._dpiIndicator;
     _liftHeight = other._liftHeight; _angleSnap = other._angleSnap;
     _needsUpdate = true; _needsSave = true;
@@ -150,11 +150,6 @@ void KbPerf::load(CkbSettings& settings){
         QColor color = settings.value("6RGB").toString();
         if(color.isValid())
             dpiClr[OTHER] = color;
-        if(settings.contains("LastIdx")){
-            dpiLastIdx = settings.value("LastIdx").toInt();
-            if(dpiLastIdx >= DPI_COUNT || dpiLastIdx < 0)
-                dpiLastIdx = 1;
-        }
 	// The current DPI is stored as a point, not an index. If this point
 	// does not exist in the table, we'll use the table entry with index 1.
         QPoint value = settings.value("Current").toPoint();
@@ -223,7 +218,6 @@ void KbPerf::save(CkbSettings& settings){
                 settings.setValue(iStr + "Disabled", !dpiOn[i]);
         }
         settings.setValue("6RGB", dpiClr[OTHER].name(QColor::HexArgb));
-        settings.setValue("LastIdx", dpiLastIdx);
 	// Ignore pushed modes when saving current DPI.
         int curX = dpi(dpiBaseIdx).x();
 	int curY = dpi(dpiBaseIdx).y();

--- a/src/ckb/kbperf.h
+++ b/src/ckb/kbperf.h
@@ -142,8 +142,6 @@ private:
     int dpiBaseIdx;
     QColor dpiClr[DPI_COUNT + 1];
     bool dpiOn[DPI_COUNT];
-    // Last-set DPI that was on the DPI list, not counting any pushed DPIs or sniper.
-    int dpiLastIdx;
 
     // Current DPI "stack." The value corresponding to the largest key is the
     // active DPI. If this is empty, we use the base DPI.

--- a/src/ckb/keyaction.cpp
+++ b/src/ckb/keyaction.cpp
@@ -333,7 +333,7 @@ void KeyAction::keyEvent(KbBind* bind, bool down){
             if(level < 1 || level >= KbPerf::DPI_COUNT
                     || !down)
                 return;
-            perf->dpi(level);
+            perf->baseDpiIdx(level);
             break;
         }
     } else if(prefix == "$light"){


### PR DESCRIPTION
We no longer set the "base DPI" - what I've called the DPI which is used when no toggled DPIs (e.g. sniper) are on the stack - by setting it to an XY value. Instead, it is always set and recorded by its index into the DPI table.

Storing an index more closely reflects the intended behaviour. Most importantly, we no longer need to deduce what the current index should be by comparing the XY value to those in the table, which cannot be done correctly when the table contains duplicate entries.

This fixes issue #298, and moreover the logic for setting the DPI and maintaining the DPI stack is simplified.