### PR TITLE
Fix daemon compilation issues in OSX 10.13.

### DIFF
--- a/src/ckb-daemon/input_mac_mouse.c
+++ b/src/ckb-daemon/input_mac_mouse.c
@@ -580,7 +580,7 @@ PACurvesSetupAccelParams (CFArrayRef parametricCurves,
             (primaryParams->gain[3].value != 0LL));
 
     // calculate secondary values
-    bzero(secondaryParams, sizeof(secondaryParams));
+    bzero(secondaryParams, sizeof(*secondaryParams));
     if ((primaryParams->tangent[1].value > 0LL) && (primaryParams->tangent[1].value < primaryParams->tangent[0].value))
         secondaryParams->firstTangent = 1;
 

--- a/src/ckb-daemon/os.h
+++ b/src/ckb-daemon/os.h
@@ -44,6 +44,9 @@
 
 #ifdef OS_MAC
 
+#define __ASSERT_MACROS_DEFINE_VERSIONS_WITHOUT_UNDERSCORES 1
+#include <AssertMacros.h>
+
 #include <Availability.h>
 #include <Carbon/Carbon.h>
 #include <IOKit/IOMessage.h>


### PR DESCRIPTION
The requires macro without leading underscores is no longer available by default. Also, the compiler now surfaces a warning which revealed a bug in the ported acceleration code.

Fixes #304.