### PR TITLE
Remove default args for KbPerf::update().

### DIFF
--- a/src/ckb/kb.cpp
+++ b/src/ckb/kb.cpp
@@ -329,7 +329,7 @@ void Kb::hwSave(){
         // Write lighting and performance
         light->base(cmd, true, monochrome);
         cmd.write(" ");
-        perf->update(cmd, true, false);
+        perf->update(cmd, notifyNumber, true, false);
         // Update mode ID
         mode->id().hwModified = mode->id().modified;
         mode->setNeedsSave();
@@ -418,7 +418,7 @@ void Kb::frameUpdate(){
     cmd.write(QString("\n@%1 ").arg(notifyNumber).toLatin1());
     bind->update(cmd, changed);
     cmd.write(" ");
-    perf->update(cmd, notifyNumber, changed);
+    perf->update(cmd, notifyNumber, changed, true);
     cmd.write("\n");
     cmd.flush();
 }

--- a/src/ckb/kbperf.h
+++ b/src/ckb/kbperf.h
@@ -112,7 +112,7 @@ public:
 
     // Updates settings to the driver. Write "mode %d" first. Disable saveCustomDpi when writing a hardware profile or other permanent storage.
     // By default, nothing will be written unless the settings have changed. Use force = true or call setNeedsUpdate() to override.
-    void        update(QFile& cmd, int notifyNumber, bool force = false, bool saveCustomDpi = true);
+    void        update(QFile& cmd, int notifyNumber, bool force, bool saveCustomDpi);
     inline void setNeedsUpdate()        { _needsUpdate = true; }
 
     // Get indicator status to send to KbLight


### PR DESCRIPTION
This function was being called with arguments of the wrong type, which was probably unintentional.

This is probably related to the regression found in #242. @frickler24 please take a look, I suspect this call was missed when adding notifyNumber to the arguments.