### PR TITLE
Add CFBundleExecutable, CFbundleName to Info.plist

### DIFF
--- a/src/ckb/ckb-info.plist
+++ b/src/ckb/ckb-info.plist
@@ -2,8 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>CFBundleExecutable</key>
+    <string>ckb</string>
     <key>CFBundleIconFile</key>
     <string>ckb-logo.icns</string>
+    <key>CFBundleName</key>
+    <string>ckb</string>
     <key>LSUIElement</key>
     <true/>
     <key>NSPrincipalClass</key>


### PR DESCRIPTION
I know the app name is changing @ 2.9 but I just wanted to make sure that `ckb` can be found by Spotlight search on macOS (it can't).  

Add the `CFBundleExecutable`, `CFBundleName` keys to the `Info.plist` for discovery in Spotlight.

Tested on macOS 10.13
