### PR TITLE
Fix #232 for Qt 5.9.x

### DIFF
--- a/quickinstall
+++ b/quickinstall
@@ -70,25 +70,6 @@ if [ -d "/usr/bin/ckb-animations" ]; then
     echo "Done"
 fi
 
-# Workaround unknown qmake bug on macOS at configuration stage which happens at generation stage
-# Assumes Homebrew is installed
-# Assumes 'qt' package by 'brew' command is installed
-# TODO: track down the version where the bug is not triggered and do not apply for older versions
-# TODO: try shooting yourself in the head with BSD utils to dynamically resolve /usr/local/opt/qt
-echo "Applying required qmake workaround"
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    if [[ ! -d "/usr/local/Cellar/qt/5.9.1" ]]; then
-        echo "Error: Cannot apply the workaround. The script assumes Homebrew is installed \
-        and the 'qt' package is installed using it (version 5.9.1). \
-        If you have installed the official Qt package, edit this script and provide proper paths \
-        or install Qt with Homebrew."
-        finish 101
-    fi
-    sed -i '' "s/version_min_flag = -m\$\${version_identifier}-version-min=\$\$deployment_target/\
-    version_min_flag = -m\$\${version_identifier}-version-min=10\.10/" \
-    /usr/local/Cellar/qt/5.9.1/mkspecs/features/mac/default_post.prf
-fi
-
 if [[ -d $SRCDIR ]]; then
     echo "Preparing build files..."
     # Clean up first
@@ -117,14 +98,6 @@ if [[ ! -d $BINDIR ]]; then
     # No binaries and no source ($SRCDIR branch will surely create $BINDIR or die trying)
     echo "There is nothing to do."
     finish 0
-fi
-
-# "Unapply" the workaround
-echo "Unapplying qmake workaround"
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    sed -i '' "s/version_min_flag = -m\$\${version_identifier}-version-min=10\.10/\
-    version_min_flag = -m\$\${version_identifier}-version-min=\$\$deployment_target/" \
-    /usr/local/Cellar/qt/5.9.1/mkspecs/features/mac/default_post.prf
 fi
 
 # Offer to install ckb at a standard location

--- a/src/ckb-daemon/ckb-daemon.pro
+++ b/src/ckb-daemon/ckb-daemon.pro
@@ -14,10 +14,10 @@ macx {
 }
 
 QMAKE_CFLAGS  += -std=gnu11 -Wall -Wextra -fsigned-char
-QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
 
 # Minimal build - remove Qt defaults
-CONFIG   = debug_and_release
+CONFIG   += debug_and_release
+CONFIG   -= app_bundle
 QT       =
 
 CKB_VERSION_STR = `cat $$PWD/../../VERSION | tr -d '\n'`

--- a/src/ckb-gradient/ckb-gradient.pro
+++ b/src/ckb-gradient/ckb-gradient.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 TARGET = ckb-gradient
 
 QMAKE_CFLAGS += -std=c99
-QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
+
 
 macx {
     DESTDIR = $$PWD/../../ckb.app/Contents/Resources/ckb-animations
@@ -10,7 +10,8 @@ macx {
     DESTDIR = $$PWD/../../bin/ckb-animations
 }
 
-CONFIG   = debug_and_release
+CONFIG   += debug_and_release
+CONFIG   -= app_bundle
 QT       =
 LIBS     =
 

--- a/src/ckb-heat/ckb-heat.pro
+++ b/src/ckb-heat/ckb-heat.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 TARGET = ckb-heat
 
 QMAKE_CFLAGS += -std=c99
-QMAKE_MAC_SDK = macosx10.10
+
 
 macx {
     DESTDIR = $$PWD/../../ckb.app/Contents/Resources/ckb-animations
@@ -10,7 +10,8 @@ macx {
     DESTDIR = $$PWD/../../bin/ckb-animations
 }
 
-CONFIG   = debug_and_release
+CONFIG   += debug_and_release
+CONFIG   -= app_bundle
 QT       =
 LIBS     = -lm
 

--- a/src/ckb-mviz/ckb-mviz.pro
+++ b/src/ckb-mviz/ckb-mviz.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 TARGET = ckb-mviz
 
 QMAKE_CFLAGS += -std=c99
-QMAKE_MAC_SDK = macosx10.10
+
 
 macx {
     DESTDIR = $$PWD/../../ckb.app/Contents/Resources/ckb-animations
@@ -10,7 +10,8 @@ macx {
     DESTDIR = $$PWD/../../bin/ckb-animations
 }
 
-CONFIG   = debug_and_release
+CONFIG   += debug_and_release
+CONFIG   -= app_bundle
 QT       =
 LIBS += -lpulse-simple
 

--- a/src/ckb-pinwheel/ckb-pinwheel.pro
+++ b/src/ckb-pinwheel/ckb-pinwheel.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 TARGET = ckb-pinwheel
 
 QMAKE_CFLAGS += -std=c99
-QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
+
 
 macx {
     DESTDIR = $$PWD/../../ckb.app/Contents/Resources/ckb-animations
@@ -10,7 +10,8 @@ macx {
     DESTDIR = $$PWD/../../bin/ckb-animations
 }
 
-CONFIG   = debug_and_release
+CONFIG   += debug_and_release
+CONFIG   -= app_bundle
 QT       =
 LIBS     =
 

--- a/src/ckb-rain/ckb-rain.pro
+++ b/src/ckb-rain/ckb-rain.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 TARGET = ckb-rain
 
 QMAKE_CFLAGS += -std=c99
-QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
+
 
 macx {
     DESTDIR = $$PWD/../../ckb.app/Contents/Resources/ckb-animations
@@ -10,7 +10,8 @@ macx {
     DESTDIR = $$PWD/../../bin/ckb-animations
 }
 
-CONFIG   = debug_and_release
+CONFIG   += debug_and_release
+CONFIG   -= app_bundle
 QT       =
 LIBS     =
 

--- a/src/ckb-random/ckb-random.pro
+++ b/src/ckb-random/ckb-random.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 TARGET = ckb-random
 
 QMAKE_CFLAGS += -std=c99
-QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
+
 
 macx {
     DESTDIR = $$PWD/../../ckb.app/Contents/Resources/ckb-animations
@@ -10,7 +10,8 @@ macx {
     DESTDIR = $$PWD/../../bin/ckb-animations
 }
 
-CONFIG   = debug_and_release
+CONFIG   += debug_and_release
+CONFIG   -= app_bundle
 QT       =
 LIBS     =
 

--- a/src/ckb-ripple/ckb-ripple.pro
+++ b/src/ckb-ripple/ckb-ripple.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 TARGET = ckb-ripple
 
 QMAKE_CFLAGS += -std=c99
-QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
+
 
 macx {
     DESTDIR = $$PWD/../../ckb.app/Contents/Resources/ckb-animations
@@ -10,7 +10,8 @@ macx {
     DESTDIR = $$PWD/../../bin/ckb-animations
 }
 
-CONFIG   = debug_and_release
+CONFIG   += debug_and_release
+CONFIG   -= app_bundle
 QT       =
 LIBS     =
 

--- a/src/ckb-wave/ckb-wave.pro
+++ b/src/ckb-wave/ckb-wave.pro
@@ -2,7 +2,7 @@ TEMPLATE = app
 TARGET = ckb-wave
 
 QMAKE_CFLAGS += -std=c99
-QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
+
 
 macx {
     DESTDIR = $$PWD/../../ckb.app/Contents/Resources/ckb-animations
@@ -10,7 +10,8 @@ macx {
     DESTDIR = $$PWD/../../bin/ckb-animations
 }
 
-CONFIG   = debug_and_release
+CONFIG   += debug_and_release
+CONFIG   -= app_bundle
 QT       =
 LIBS     =
 

--- a/src/ckb/ckb-info.plist
+++ b/src/ckb/ckb-info.plist
@@ -5,9 +5,11 @@
     <key>CFBundleExecutable</key>
     <string>ckb</string>
     <key>CFBundleIconFile</key>
-    <string>ckb-logo.icns</string>
+    <string>@ICON@</string>
     <key>CFBundleName</key>
     <string>ckb</string>
+    <key>CFBundleShortVersionString</key>
+    <string>@SHORT_VERSION@</string>
     <key>LSUIElement</key>
     <true/>
     <key>NSPrincipalClass</key>

--- a/src/ckb/ckb.pro
+++ b/src/ckb/ckb.pro
@@ -1,6 +1,8 @@
 QT       += core gui widgets network
 CONFIG   += debug_and_release
 
+VERSION = 0.2.8
+
 TARGET = ckb
 TEMPLATE = app
 # GL isn't needed
@@ -22,7 +24,6 @@ macx {
 }
 
 # OSX settings
-QMAKE_MACOSX_DEPLOYMENT_TARGET = 10.9
 ICON = ckb-logo.icns
 QMAKE_INFO_PLIST = ckb-info.plist
 macx {


### PR DESCRIPTION
So I think I figured out #232. It seems like Qt changed a bit and we need to set `CONFIG += debug_and_release` instead of just `CONFIG= ....` in the subproject `.pro` files.  Also need to `-= app_bundle` so these are created as unix executables instead of macOS apps.

So this should preclude the need to hardcode the version by modifying the Qt compiler source and allow the `QMAKE_MACOSX_DEPLOYMENT_TARGET` environmental variable to just work.

I'm able to compile in both Qt Creator 4.4.1 and from the commandline with
`QMAKE=~/local/Qt/5.9.2/clang_64/bin/qmake QMAKE_MACOSX_DEPLOYMENT_TARGET=10.10 ./qmake-auto && make` against an unmodified Qt installation.

Tested on macOS 10.13/Qt 5.9.2