### PR TITLE
Reduce idle CPU usage

### DIFF
--- a/src/ckb/colormap.cpp
+++ b/src/ckb/colormap.cpp
@@ -24,6 +24,22 @@ const ColorMap& ColorMap::operator=(const ColorMap& rhs){
     return rhs;
 }
 
+bool ColorMap::operator==(const ColorMap& rhs) const{
+    if(_count != rhs._count)
+        return false;
+
+    // Compare just the pointers because key names are sorted and the strings are constants.
+    if(memcmp(_keyNames, rhs._keyNames, sizeof(const char*) * _count) != 0)
+        return false;
+
+    for(int x = 0;x < _count;x++){
+        if(_colors[x] != rhs._colors[x])
+            return false;
+    }
+
+    return true;
+}
+
 void ColorMap::alloc(int newCount){
     if(newCount > _mapCount){
         // ^ map never shrinks, only expands

--- a/src/ckb/colormap.h
+++ b/src/ckb/colormap.h
@@ -19,6 +19,7 @@ public:
     ~ColorMap();
     ColorMap(const ColorMap& rhs);
     const ColorMap& operator=(const ColorMap& rhs);
+    bool operator==(const ColorMap& rhs) const;
 
     // Initialize the color map with the given keys. Color values are initialized to transparent black.
     // This may be called more than once; the existing color set will be erased.

--- a/src/ckb/kblight.h
+++ b/src/ckb/kblight.h
@@ -90,10 +90,10 @@ private:
     KbAnim*         _previewAnim;
     KeyMap          _map;
     QColorMap       _qColorMap;
-    ColorMap        _colorMap, _animMap, _indicatorMap;
+    ColorMap        _colorMap, _animMap, _lastFrameAnimMap, _indicatorMap, _lastFrameIndicatorMap;
     QSet<QString>   _indicatorList;
     quint64         lastFrameSignal;
-    int             _dimming;
+    int             _dimming, _lastFrameDimming;
     bool            _start;
     bool            _needsSave, _needsMapRefresh;
 

--- a/src/ckb/kbmanager.cpp
+++ b/src/ckb/kbmanager.cpp
@@ -28,8 +28,11 @@ KbManager::KbManager(QObject *parent) : QObject(parent){
     _eventTimer = new QTimer(this);
     _eventTimer->setTimerType(Qt::PreciseTimer);
     _scanTimer = new QTimer(this);
-    _scanTimer->start(100);
+    _scanTimer->start(1000);
     connect(_scanTimer, SIGNAL(timeout()), this, SLOT(scanKeyboards()));
+
+    // Scan for keyboards immediately so they show up as soon as the GUI appears.
+    QTimer::singleShot(0,this,SLOT(scanKeyboards()));
 }
 
 void KbManager::fps(int framerate){


### PR DESCRIPTION
This builds on #294 to reduce CPU usage according to `top` when no animations are playing. I'm seeing a reduction from 1.3% to 0.0% with an occasional 0.3% using these changes.

The first change is to reduce the polling rate for finding new hardware from 100ms to 1000ms. The old rate was accounting for 0.4% of the CPU usage. Ideally, the GUI could be notified of new hardware by having a thread call `poll()` on a socket descriptor instead of continuously launching a process. That's a lot more work to implement so I see this as a reasonable trade off.

The other change involves caching the state of the keyboard lights before blending and only continuing if they have changed. I experimented with restricting this behavior to only when no animations are playing. But, letting it run during animations doesn't show an increase in CPU according to `top`.

These changes are kind of nitpicking but maybe someone running a laptop on battery might appreciate them. :smile: