### PR TITLE
Add key map and modify RGB buffer for K95 Platinum lightbar

### DIFF
--- a/src/ckb-daemon/keymap.c
+++ b/src/ckb-daemon/keymap.c
@@ -157,27 +157,32 @@ const key keymap[N_KEYS_EXTENDED] = {
     { 0,            -1,   KEY_NONE },
     { 0,            -1,   KEY_NONE },
 
+    // K95 Platinum
+    { "topbar1",      0x90, KEY_NONE },
+    { "topbar2",      0x91, KEY_NONE },
+    { "topbar3",      0x92, KEY_NONE },
+    { "topbar4",      0x9E, KEY_NONE },
+    { "topbar5",      0xA0, KEY_NONE },
+    { "topbar6",      0x93, KEY_NONE },
+    { "topbar7",      0x94, KEY_NONE },
+    { "topbar8",      0x95, KEY_NONE },
+    { "topbar9",      0x96, KEY_NONE },
+    { "topbar10",     0x97, KEY_NONE },
+    { "topbar11",     0x98, KEY_NONE },
+    { "topbar12",     0x99, KEY_NONE },
+    { "topbar13",     0x9A, KEY_NONE },
+    { "topbar14",     0x9B, KEY_NONE },
+    { "topbar15",     0x9F, KEY_NONE },
+    { "topbar16",     0xA2, KEY_NONE },
+    { "topbar17",     0xA1, KEY_NONE },
+    { "topbar18",     0x9C, KEY_NONE },
+    { "topbar19",     0x9D, KEY_NONE },
+
     // Strafe specific side leds, that are set via a special command
     { "lsidel",      -2, KEY_CORSAIR },
     { "rsidel",      -2, KEY_CORSAIR },
     // Strafe logo backlight
     { "logo",      0x7d, KEY_CORSAIR },
-
-    // K95 Platinum 
-    { "topbar1",      0x97, KEY_NONE },
-    { "topbar2",      0x98, KEY_NONE },
-    { "topbar3",      0x99, KEY_NONE },
-    { "topbar4",      0x9A, KEY_NONE },
-    { "topbar5",      0x9B, KEY_NONE },
-    { "topbar6",      0x9C, KEY_NONE },
-    { "topbar7",      0x9D, KEY_NONE },
-    { "topbar8",      0x9E, KEY_NONE },
-    { "topbar9",      0x9F, KEY_NONE },
-    { "topbar10",     0xA0, KEY_NONE },
-    { "topbar11",     0xA1, KEY_NONE },
-    { "topbar12",     0xA2, KEY_NONE },
-    { "topbar13",     0xA3, KEY_NONE },
-    { "topbar14",     0xA4, KEY_NONE },
 
     // Keys not present on any device
     { "lightup",    -1, KEY_BRIGHTNESSUP },

--- a/src/ckb-daemon/keymap.h
+++ b/src/ckb-daemon/keymap.h
@@ -24,7 +24,7 @@
 #define N_KEYS_HW               152
 #define N_KEYBYTES_HW           ((N_KEYS_HW + 7) / 8)
 // Light zones (have LED codes but don't generate input)
-#define N_KEY_ZONES             17       // two strafe side lights (although really they are tied into one control) + logo backlight + Platinum top bar
+#define N_KEY_ZONES             22      // two strafe side lights (although really they are tied into one control) + logo backlight + Platinum top bar
 // Additional keys recognized by the driver but may not be present on keyboard
 #define N_KEYS_EXTRA            12
 // Mouse buttons

--- a/src/ckb-daemon/led_keyboard.c
+++ b/src/ckb-daemon/led_keyboard.c
@@ -117,6 +117,13 @@ int updatergb_kb(usbdevice* kb, int force){
             { 0x7f, 0x03, 0x18, 0 },
             { 0x07, 0x28, 0x03, 0x03, 0x02, 0}
         };
+        // The K95 Platinum needs 0x30 for the lightbar to work, due to the length of the packet.
+        // A way to dynamically calculate the length would be preferred, based on the device.
+        if(kb->product == P_K95_PLATINUM){
+            data_pkt[2][2] = 0x30;
+            data_pkt[6][2] = 0x30;
+            data_pkt[10][2] = 0x30;
+        }
         makergb_full(newlight, data_pkt);
         if(!usbsend(kb, data_pkt[0], 12))
             return -1;

--- a/src/ckb-daemon/led_keyboard.c
+++ b/src/ckb-daemon/led_keyboard.c
@@ -60,15 +60,15 @@ static void makergb_full(const lighting* light, uchar data_pkt[12][MSG_SIZE]){
     // Red
     memcpy(data_pkt[0] + 4, r, 60);
     memcpy(data_pkt[1] + 4, r + 60, 60);
-    memcpy(data_pkt[2] + 4, r + 120, 24);
+    memcpy(data_pkt[2] + 4, r + 120, 60);
     // Green (final R packet is blank)
     memcpy(data_pkt[4] + 4, g, 60);
     memcpy(data_pkt[5] + 4, g + 60, 60);
-    memcpy(data_pkt[6] + 4, g + 120, 24);
+    memcpy(data_pkt[6] + 4, g + 120, 60);
     // Blue (final G packet is blank)
     memcpy(data_pkt[8] + 4, b, 60);
     memcpy(data_pkt[9] + 4, b + 60, 60);
-    memcpy(data_pkt[10] + 4, b + 120, 24);
+    memcpy(data_pkt[10] + 4, b + 120, 60);
 }
 
 static int rgbcmp(const lighting* lhs, const lighting* rhs){


### PR DESCRIPTION
Still need to add conditional logic for the K95 Platinum to match what we saw from CUE (`0x30` instead of `0x18`):

https://github.com/mattanger/ckb-next/blob/newdev/src/ckb-daemon/led_keyboard.c#L107

Also, we need to investigate these to get the right values:

https://github.com/mattanger/ckb-next/blob/newdev/src/ckb-daemon/keymap.h#L24
https://github.com/mattanger/ckb-next/blob/newdev/src/ckb-daemon/keymap.h#L27