### PR TITLE
Add explicit tabbing-order to ui files

### DIFF
--- a/src/ckb/animsettingdialog.ui
+++ b/src/ckb/animsettingdialog.ui
@@ -481,6 +481,16 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+  <tabstop>animName</tabstop>
+  <tabstop>delayBox</tabstop>
+  <tabstop>repeatBox</tabstop>
+  <tabstop>kpModeStopBox</tabstop>
+  <tabstop>kpDelayBox</tabstop>
+  <tabstop>kpRepeatBox</tabstop>
+  <tabstop>kpReleaseBox</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/ckb/extrasettingswidget.ui
+++ b/src/ckb/extrasettingswidget.ui
@@ -515,6 +515,17 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>trayBox</tabstop>
+  <tabstop>brightnessBox</tabstop>
+  <tabstop>animScanButton</tabstop>
+  <tabstop>fpsBox</tabstop>
+  <tabstop>ditherBox</tabstop>
+  <tabstop>delayBox</tabstop>
+  <tabstop>mAccelBox</tabstop>
+  <tabstop>sAccelBox</tabstop>
+  <tabstop>sSpeedBox</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/ckb/fwupgradedialog.ui
+++ b/src/ckb/fwupgradedialog.ui
@@ -192,6 +192,10 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>actionButton</tabstop>
+  <tabstop>cancelButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ckb/gradientdialog.ui
+++ b/src/ckb/gradientdialog.ui
@@ -37,6 +37,12 @@
      <property name="sizeType">
       <enum>QSizePolicy::Expanding</enum>
      </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
     </spacer>
    </item>
    <item row="3" column="0">
@@ -287,6 +293,15 @@
    <header>colorbutton.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>presetList</tabstop>
+  <tabstop>presetName</tabstop>
+  <tabstop>presetSave</tabstop>
+  <tabstop>presetDelete</tabstop>
+  <tabstop>stopPos</tabstop>
+  <tabstop>stopColor</tabstop>
+  <tabstop>stopOpacity</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/ckb/kbbindwidget.ui
+++ b/src/ckb/kbbindwidget.ui
@@ -239,11 +239,6 @@
     </widget>
    </item>
   </layout>
-  <zorder>label</zorder>
-  <zorder>line</zorder>
-  <zorder>label_2</zorder>
-  <zorder>line_2</zorder>
-  <zorder>widget</zorder>
  </widget>
  <customwidgets>
   <customwidget>
@@ -259,6 +254,10 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>copyButton</tabstop>
+  <tabstop>resetButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ckb/kblightwidget.ui
+++ b/src/ckb/kblightwidget.ui
@@ -341,15 +341,15 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>ColorButton</class>
+   <extends>QPushButton</extends>
+   <header>colorbutton.h</header>
+  </customwidget>
+  <customwidget>
    <class>KeyWidget</class>
    <extends>QWidget</extends>
    <header>keywidget.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ColorButton</class>
-   <extends>QPushButton</extends>
-   <header>colorbutton.h</header>
   </customwidget>
   <customwidget>
    <class>KbAnimWidget</class>
@@ -358,6 +358,12 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>showAnimBox</tabstop>
+  <tabstop>bgButton</tabstop>
+  <tabstop>animButton</tabstop>
+  <tabstop>brightnessBox</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ckb/kbprofiledialog.ui
+++ b/src/ckb/kbprofiledialog.ui
@@ -78,6 +78,9 @@
    <header>rlistwidget.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>profileList</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/ckb/kperfwidget.ui
+++ b/src/ckb/kperfwidget.ui
@@ -1061,9 +1061,39 @@
   <customwidget>
    <class>ColorButton</class>
    <extends>QPushButton</extends>
-   <header location="global">colorbutton.h</header>
+   <header>colorbutton.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>intensityBox</tabstop>
+  <tabstop>copyButton</tabstop>
+  <tabstop>modeBox</tabstop>
+  <tabstop>modeColorOn</tabstop>
+  <tabstop>modeColorOff</tabstop>
+  <tabstop>macroBox</tabstop>
+  <tabstop>macroColorOn</tabstop>
+  <tabstop>macroColorOff</tabstop>
+  <tabstop>lightBox</tabstop>
+  <tabstop>lightColor3</tabstop>
+  <tabstop>lightColor2</tabstop>
+  <tabstop>lightColor1</tabstop>
+  <tabstop>lockBox</tabstop>
+  <tabstop>lockColorOn</tabstop>
+  <tabstop>lockColorOff</tabstop>
+  <tabstop>muteBox</tabstop>
+  <tabstop>muteColorOn</tabstop>
+  <tabstop>muteColorOff</tabstop>
+  <tabstop>muteColorNA</tabstop>
+  <tabstop>numBox</tabstop>
+  <tabstop>numColorOn</tabstop>
+  <tabstop>numColorOff</tabstop>
+  <tabstop>capsBox</tabstop>
+  <tabstop>capsColorOn</tabstop>
+  <tabstop>capsColorOff</tabstop>
+  <tabstop>scrollBox</tabstop>
+  <tabstop>scrollColorOn</tabstop>
+  <tabstop>scrollColorOff</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ckb/layoutdialog.ui
+++ b/src/ckb/layoutdialog.ui
@@ -145,6 +145,9 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>comboBox</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/ckb/mainwindow.ui
+++ b/src/ckb/mainwindow.ui
@@ -52,6 +52,9 @@
   </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <tabstops>
+  <tabstop>tabWidget</tabstop>
+ </tabstops>
  <resources>
   <include location="image.qrc"/>
  </resources>

--- a/src/ckb/modeselectdialog.ui
+++ b/src/ckb/modeselectdialog.ui
@@ -63,6 +63,11 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>modeList</tabstop>
+  <tabstop>selAllButton</tabstop>
+  <tabstop>selNoneButton</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/ckb/mperfwidget.ui
+++ b/src/ckb/mperfwidget.ui
@@ -1045,9 +1045,53 @@
   <customwidget>
    <class>ColorButton</class>
    <extends>QPushButton</extends>
-   <header location="global">colorbutton.h</header>
+   <header>colorbutton.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>indicBox</tabstop>
+  <tabstop>spinBox</tabstop>
+  <tabstop>xyBox</tabstop>
+  <tabstop>eBox1</tabstop>
+  <tabstop>eBox2</tabstop>
+  <tabstop>eBox3</tabstop>
+  <tabstop>eBox4</tabstop>
+  <tabstop>eBox5</tabstop>
+  <tabstop>iButton1</tabstop>
+  <tabstop>iButton2</tabstop>
+  <tabstop>iButton3</tabstop>
+  <tabstop>iButton4</tabstop>
+  <tabstop>iButton5</tabstop>
+  <tabstop>iButton0</tabstop>
+  <tabstop>iButtonO</tabstop>
+  <tabstop>xSlider1</tabstop>
+  <tabstop>xSlider2</tabstop>
+  <tabstop>xSlider3</tabstop>
+  <tabstop>xSlider4</tabstop>
+  <tabstop>xSlider5</tabstop>
+  <tabstop>xSlider0</tabstop>
+  <tabstop>xBox1</tabstop>
+  <tabstop>xBox2</tabstop>
+  <tabstop>xBox3</tabstop>
+  <tabstop>xBox4</tabstop>
+  <tabstop>xBox5</tabstop>
+  <tabstop>xBox0</tabstop>
+  <tabstop>ySlider1</tabstop>
+  <tabstop>ySlider2</tabstop>
+  <tabstop>ySlider3</tabstop>
+  <tabstop>ySlider4</tabstop>
+  <tabstop>ySlider5</tabstop>
+  <tabstop>ySlider0</tabstop>
+  <tabstop>yBox1</tabstop>
+  <tabstop>yBox2</tabstop>
+  <tabstop>yBox3</tabstop>
+  <tabstop>yBox4</tabstop>
+  <tabstop>yBox5</tabstop>
+  <tabstop>yBox0</tabstop>
+  <tabstop>aSnapBox</tabstop>
+  <tabstop>lHeightBox</tabstop>
+  <tabstop>copyButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/ckb/rebindwidget.ui
+++ b/src/ckb/rebindwidget.ui
@@ -26,7 +26,7 @@
       <string notr="true"/>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>5</number>
      </property>
      <property name="usesScrollButtons">
       <bool>false</bool>
@@ -1387,8 +1387,8 @@
         <rect>
          <x>300</x>
          <y>10</y>
-         <width>111</width>
-         <height>71</height>
+         <width>131</width>
+         <height>74</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -1598,6 +1598,7 @@
         <set>Qt::NoTextInteraction</set>
        </property>
       </widget>
+      <zorder>pteMacroComment</zorder>
       <zorder>layoutWidget</zorder>
       <zorder>layoutWidget1</zorder>
       <zorder>layoutWidget</zorder>
@@ -1660,56 +1661,59 @@
  </widget>
  <tabstops>
   <tabstop>tabWidget</tabstop>
-  <tabstop>pteMacroComment</tabstop>
-  <tabstop>pteMacroBox</tabstop>
-  <tabstop>dpiButton</tabstop>
-  <tabstop>mb2Box</tabstop>
-  <tabstop>btnStartMacro</tabstop>
+  <tabstop>typingButton</tabstop>
+  <tabstop>typingBox</tabstop>
+  <tabstop>modButton</tabstop>
+  <tabstop>modBox</tabstop>
+  <tabstop>fnButton</tabstop>
   <tabstop>fnBox</tabstop>
-  <tabstop>dpiCustYBox</tabstop>
-  <tabstop>dpiBox</tabstop>
-  <tabstop>applyButton</tabstop>
-  <tabstop>mbBox</tabstop>
-  <tabstop>cancelButton</tabstop>
-  <tabstop>wheelBox</tabstop>
-  <tabstop>btnStopMacro</tabstop>
+  <tabstop>numButton</tabstop>
+  <tabstop>numBox</tabstop>
+  <tabstop>mediaButton</tabstop>
+  <tabstop>mediaBox</tabstop>
   <tabstop>mbButton</tabstop>
-  <tabstop>dpiCustXBox</tabstop>
-  <tabstop>btnClearMacro</tabstop>
-  <tabstop>wheelButton</tabstop>
+  <tabstop>mbBox</tabstop>
   <tabstop>mb2Button</tabstop>
-  <tabstop>animBox</tabstop>
-  <tabstop>animKrBox</tabstop>
-  <tabstop>animOnceBox</tabstop>
+  <tabstop>mb2Box</tabstop>
+  <tabstop>wheelButton</tabstop>
+  <tabstop>wheelBox</tabstop>
+  <tabstop>dpiButton</tabstop>
+  <tabstop>dpiBox</tabstop>
+  <tabstop>dpiCustXBox</tabstop>
+  <tabstop>dpiCustYBox</tabstop>
   <tabstop>animButton</tabstop>
+  <tabstop>animBox</tabstop>
+  <tabstop>animOnceBox</tabstop>
+  <tabstop>animKrBox</tabstop>
   <tabstop>modeButton</tabstop>
+  <tabstop>modeBox</tabstop>
   <tabstop>modeWrapBox</tabstop>
+  <tabstop>lightButton</tabstop>
+  <tabstop>lightBox</tabstop>
   <tabstop>lightWrapBox</tabstop>
   <tabstop>lockButton</tabstop>
-  <tabstop>lightBox</tabstop>
-  <tabstop>resetButton</tabstop>
   <tabstop>lockBox</tabstop>
-  <tabstop>lightButton</tabstop>
-  <tabstop>modeBox</tabstop>
-  <tabstop>unbindButton</tabstop>
   <tabstop>programKpButton</tabstop>
   <tabstop>programKpBox</tabstop>
-  <tabstop>programKrBox</tabstop>
-  <tabstop>programKrButton</tabstop>
   <tabstop>programKpSIBox</tabstop>
   <tabstop>programKpModeBox</tabstop>
+  <tabstop>programKrButton</tabstop>
+  <tabstop>programKrBox</tabstop>
   <tabstop>programKrSIBox</tabstop>
   <tabstop>programKrModeBox</tabstop>
-  <tabstop>typingBox</tabstop>
-  <tabstop>numBox</tabstop>
+  <tabstop>pteMacroBox</tabstop>
+  <tabstop>rb_delay_no</tabstop>
+  <tabstop>rb_delay_default</tabstop>
+  <tabstop>rb_delay_asTyped</tabstop>
+  <tabstop>pteMacroComment</tabstop>
   <tabstop>pteMacroText</tabstop>
-  <tabstop>typingButton</tabstop>
-  <tabstop>mediaButton</tabstop>
-  <tabstop>modBox</tabstop>
-  <tabstop>modButton</tabstop>
-  <tabstop>fnButton</tabstop>
-  <tabstop>mediaBox</tabstop>
-  <tabstop>numButton</tabstop>
+  <tabstop>btnStartMacro</tabstop>
+  <tabstop>btnStopMacro</tabstop>
+  <tabstop>btnClearMacro</tabstop>
+  <tabstop>unbindButton</tabstop>
+  <tabstop>resetButton</tabstop>
+  <tabstop>cancelButton</tabstop>
+  <tabstop>applyButton</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/src/ckb/settingswidget.ui
+++ b/src/ckb/settingswidget.ui
@@ -19,11 +19,11 @@
      <property name="text">
       <string>© 2014-2016 &lt;a href=&quot;https://github.com/ccMSC/&quot; style=&quot;text-decoration:none;&quot;&gt;ccMSC&lt;/a&gt;.&lt;br/&gt;© 2017 &lt;a href=&quot;https://github.com/mattanger/ckb-next/graphs/contributors&quot; style=&quot;text-decoration:none;&quot;&gt;The ckb-next development team&lt;/a&gt;.</string>
      </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
@@ -510,6 +510,18 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>layoutBox</tabstop>
+  <tabstop>capsBox</tabstop>
+  <tabstop>shiftBox</tabstop>
+  <tabstop>ctrlBox</tabstop>
+  <tabstop>winBox</tabstop>
+  <tabstop>altBox</tabstop>
+  <tabstop>autoFWBox</tabstop>
+  <tabstop>loginItemBox</tabstop>
+  <tabstop>extraButton</tabstop>
+  <tabstop>pushButton</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Use Qt-Designer to re-arrange the order in which individual fields in
the UI are cycled, if pressing <TAB> repeatedly. The actual order is
completely biased (and can be changed if required).