### PR TITLE
Fix mouse for v3

### DIFF
--- a/src/ckb-daemon/usb_linux.c
+++ b/src/ckb-daemon/usb_linux.c
@@ -349,7 +349,7 @@ void* os_inputmain(void* context){
                 case 10:
                 case 11:
                     // HID mouse input
-                    hid_mouse_translate(kb->input.keys, &kb->input.rel_x, &kb->input.rel_y, -(urb->endpoint & 0xF), urb->actual_length, urb->buffer, kb->fwversion);
+                    hid_mouse_translate(kb->input.keys, &kb->input.rel_x, &kb->input.rel_y, -urbendpoint, urb->actual_length, urb->buffer, kb->fwversion);
                     break;
                 case MSG_SIZE:
                     // Corsair mouse input


### PR DESCRIPTION
`-(urb->endpoint & 0xF)` is `-1` on v3 because the endpoints have changed, so use `-urbendpoint` instead, which overrides this.