### PR TITLE
Add udev rule, fixes #357

### DIFF
--- a/quickinstall
+++ b/quickinstall
@@ -150,8 +150,11 @@ else
     checkfail $?
     sudo xdg-desktop-menu install --novendor usr/ckb.desktop 2>"$TMPFILE"
     checkfail $?
+    sudo install -m 644 udev/99-ckb-daemon.rules /etc/udev/rules.d/ 2>"$TMPFILE"
+    checkfail $?
     echo "Binaries were installed under $PREFIX/bin"
     echo "Animations were installed under $PREFIX/lib/ckb-animations"
+    echo "Udev rule was installed under /etc/udev/rules.d"
 fi
 
 # Offer to run as a system service

--- a/udev/99-ckb-daemon.rules
+++ b/udev/99-ckb-daemon.rules
@@ -1,0 +1,1 @@
+ACTION=="add|change", SUBSYSTEM=="input", ATTRS{name}=="ckb[0-9]: [A-Za-z0-9]*", ENV{ID_INPUT_JOYSTICK}=""


### PR DESCRIPTION
This rule is needed to not mark the ckb-daemon devices as joysticks, introducing problems such as #357 .