### PR TITLE
Debug message additions

### DIFF
--- a/src/ckb-daemon/device.c
+++ b/src/ckb-daemon/device.c
@@ -71,9 +71,18 @@ int _start_dev(usbdevice* kb, int makeactive){
             kb->features &= ~FEAT_HWLOAD;
         }
     }
-    // Active software mode if requested
+    // Activate software mode if requested
     if(makeactive)
         return setactive(kb, 1);
+    #ifdef DEBUG
+    // 12 for each device + null terminator
+    char devlist[12*(DEV_MAX-1)+1];
+    int devlistpos = 0;
+    for(unsigned i = 1; i < DEV_MAX; i++){
+        devlistpos += sprintf(&devlist[devlistpos], "%u: 0x%x; ", i, keyboard[i].product);
+    }
+    ckb_info("Attached Devices: %s\n", devlist);
+    #endif
     return 0;
 }
 

--- a/src/ckb-daemon/usb_linux.c
+++ b/src/ckb-daemon/usb_linux.c
@@ -576,7 +576,7 @@ int os_setupusb(usbdevice* kb) {
     ///
     const char* ep_str = udev_device_get_sysattr_value(dev, "bNumInterfaces");
 #ifdef DEBUG
-    ckb_info("claiming interfaces. name=%s, firmware=%s; Got >>%s<< as ep_str\n", name, firmware, ep_str);
+    ckb_info("claiming interfaces. name=%s, firmware=%s; ep_str=%s\n", name, firmware, ep_str);
 #endif //DEBUG
     kb->epcount = 0;
     if(ep_str)


### PR DESCRIPTION
This PR slightly alters the output format of the "claiming interfaces" so that it is a bit more consistent.

Additionally, a new message is printed to the console, indicating which ckb[0-9] nodes are mapped to which devices.